### PR TITLE
Remove Cloudflare Turnstile verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,9 @@ can be managed from Directus.
    NEXT_PUBLIC_DIRECTUS_URL=https://your-directus.example.com
    DIRECTUS_STATIC_TOKEN=YOUR_STATIC_TOKEN
    NEXT_PUBLIC_SITE_NAME=Glenview Ultimate
-   NEXT_PUBLIC_TURNSTILE_SITE_KEY=your_turnstile_site_key
-   TURNSTILE_SECRET_KEY=your_turnstile_secret_key
    ```
 
    **Note:** `NEXT_PUBLIC_DIRECTUS_URL` is needed for client components (like the navbar logo) to access Directus assets. It should match `DIRECTUS_URL`.
-
-   **Cloudflare Turnstile** (bot protection):
-   - Get your keys from https://dash.cloudflare.com → Turnstile
-   - Create a site and copy the Site Key and Secret Key
-   - Add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (public, used in frontend)
-   - Add `TURNSTILE_SECRET_KEY` (private, used for server-side verification)
-   - If keys are not set, the form will still work but verification will be skipped (development mode)
 2. Install and run:
    ```bash
    npm i
@@ -99,7 +90,7 @@ can be managed from Directus.
 ## 4) Hardening & production notes
 
 - Create a **separate static token** with the minimum scope (create on `registrations` only).
-- **Cloudflare Turnstile** is already integrated on the registration form with server-side verification in `/api/register`.
+- Add bot protection/rate limiting to the registration form (e.g., Cloudflare Turnstile, hCaptcha, or rate limiting middleware).
 - Add field **validation** in Directus (required, email format, etc.).
 - Add **CORS** settings in Directus if you later move to direct client reads.
 - Use **revalidate** or on-demand revalidation webhooks for fresher content.

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,11 +35,9 @@ Tests are located in the `__tests__` directory, mirroring the source structure:
 ### ✅ Implemented
 
 1. **API Route Tests** (`__tests__/api/register/route.test.ts`)
-   - Turnstile token verification (valid/invalid/missing)
    - Missing Directus credentials handling
    - Successful registration flow
    - Duplicate email error handling
-   - Payload sanitization (removing turnstile_token)
 
 2. **Directus Helper Tests** (`__tests__/lib/directus.test.ts`)
    - `getDirectusAssetUrl()` function
@@ -50,10 +48,10 @@ Tests are located in the `__tests__` directory, mirroring the source structure:
 
 1. **Registration Form Component** (`app/register/page.tsx`)
    - Form validation
-   - Turnstile widget integration
    - Form submission flow
    - Error message display
    - Child addition/removal
+   - Parent addition/removal
 
 2. **Navbar Component** (`components/navbar.tsx`)
    - Logo rendering
@@ -113,7 +111,6 @@ describe('/api/register', () => {
 ## Mocking
 
 - **Next.js Router**: Mocked in `jest.setup.js`
-- **Turnstile**: Mocked in `jest.setup.js`
 - **Fetch API**: Mocked per test using `global.fetch = jest.fn()`
 - **Environment Variables**: Set/unset per test using `process.env`
 

--- a/__tests__/api/register/route.test.ts
+++ b/__tests__/api/register/route.test.ts
@@ -56,99 +56,7 @@ describe('/api/register', () => {
       body: JSON.stringify(body),
     })
 
-  describe('Turnstile verification', () => {
-    it('should reject request without Turnstile token', async () => {
-      const req = createRequest({
-        parent1_name: 'Test Parent',
-        parent1_email: 'test@example.com',
-      })
-
-      const response = await POST(req)
-      const data = await response.json()
-
-      expect(response.status).toBe(400)
-      expect(data.error).toBe('Verification token missing')
-    })
-
-    it('should reject request with invalid Turnstile token', async () => {
-      process.env.TURNSTILE_SECRET_KEY = 'test-secret'
-
-      // Mock Turnstile verification failure
-      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: false }),
-      })
-
-      const req = createRequest({
-        parent1_name: 'Test Parent',
-        parent1_email: 'test@example.com',
-        turnstile_token: 'invalid-token',
-      })
-
-      const response = await POST(req)
-      const data = await response.json()
-
-      expect(response.status).toBe(400)
-      expect(data.error).toBe('Verification failed. Please try again.')
-    })
-
-    it('should accept request with valid Turnstile token', async () => {
-      process.env.TURNSTILE_SECRET_KEY = 'test-secret'
-
-      // Mock Turnstile verification success
-      ;(global.fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ success: true }),
-        })
-        // Mock Directus success
-        .mockResolvedValueOnce({
-          ok: true,
-          text: async () => JSON.stringify({ data: { id: 1 } }),
-        })
-
-      const req = createRequest({
-        parent1_name: 'Test Parent',
-        parent1_email: 'test@example.com',
-        turnstile_token: 'valid-token',
-      })
-
-      const response = await POST(req)
-      const data = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(data.ok).toBe(true)
-    })
-
-    it('should skip verification when TURNSTILE_SECRET_KEY is not set', async () => {
-      delete process.env.TURNSTILE_SECRET_KEY
-
-      // Mock Directus success
-      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        text: async () => JSON.stringify({ data: { id: 1 } }),
-      })
-
-      const req = createRequest({
-        parent1_name: 'Test Parent',
-        parent1_email: 'test@example.com',
-        turnstile_token: 'any-token',
-      })
-
-      const response = await POST(req)
-      const data = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(data.ok).toBe(true)
-      // Should not call Turnstile API (only Directus)
-      expect(global.fetch).toHaveBeenCalledTimes(1)
-    })
-  })
-
   describe('Directus integration', () => {
-    beforeEach(() => {
-      process.env.TURNSTILE_SECRET_KEY = 'test-secret'
-    })
 
     it('should return error when Directus credentials are missing', async () => {
       delete process.env.DIRECTUS_URL
@@ -156,7 +64,6 @@ describe('/api/register', () => {
       const req = createRequest({
         parent1_name: 'Test Parent',
         parent1_email: 'test@example.com',
-        turnstile_token: 'valid-token',
       })
 
       const response = await POST(req)
@@ -166,47 +73,9 @@ describe('/api/register', () => {
       expect(data.error).toBe('Server missing Directus credentials')
     })
 
-    it('should remove turnstile_token from payload before sending to Directus', async () => {
-      // Mock Turnstile verification success
-      ;(global.fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ success: true }),
-        })
-        // Mock Directus success
-        .mockResolvedValueOnce({
-          ok: true,
-          text: async () => JSON.stringify({ data: { id: 1 } }),
-        })
-
-      const req = createRequest({
-        parent1_name: 'Test Parent',
-        parent1_email: 'test@example.com',
-        turnstile_token: 'valid-token',
-        children: [],
-      })
-
-      await POST(req)
-
-      // Check that Directus was called without turnstile_token
-      const directusCall = (global.fetch as jest.Mock).mock.calls.find(
-        (call) => typeof call[0] === 'string' && call[0].includes('/items/registrations')
-      )
-      expect(directusCall).toBeDefined()
-      const requestBody = JSON.parse(directusCall![1].body as string)
-      expect(requestBody.turnstile_token).toBeUndefined()
-      expect(requestBody.parent1_name).toBe('Test Parent')
-    })
-
     it('should handle duplicate email error', async () => {
-      // Mock Turnstile verification success
-      ;(global.fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ success: true }),
-        })
-        // Mock Directus duplicate error
-        .mockResolvedValueOnce({
+      // Mock Directus duplicate error
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,
           status: 400,
           text: async () =>
@@ -226,7 +95,6 @@ describe('/api/register', () => {
       const req = createRequest({
         parent1_name: 'Test Parent',
         parent1_email: 'test@example.com',
-        turnstile_token: 'valid-token',
       })
 
       const response = await POST(req)
@@ -238,14 +106,8 @@ describe('/api/register', () => {
     })
 
     it('should handle successful registration', async () => {
-      // Mock Turnstile verification success
-      ;(global.fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ success: true }),
-        })
-        // Mock Directus success
-        .mockResolvedValueOnce({
+      // Mock Directus success
+      ;(global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: true,
           text: async () => JSON.stringify({ data: { id: 123 } }),
         })
@@ -253,7 +115,6 @@ describe('/api/register', () => {
       const req = createRequest({
         parent1_name: 'Test Parent',
         parent1_email: 'test@example.com',
-        turnstile_token: 'valid-token',
         children: [{ full_name: 'Child 1' }],
       })
 

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,26 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
 
-async function verifyTurnstileToken(token: string): Promise<boolean> {
-  const secretKey = process.env.TURNSTILE_SECRET_KEY;
-  if (!secretKey) {
-    console.warn("TURNSTILE_SECRET_KEY not set, skipping verification");
-    return true; // Allow in development if key not set
-  }
-
-  try {
-    const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ secret: secretKey, response: token }),
-    });
-    const data = await response.json();
-    return data.success === true;
-  } catch (error) {
-    console.error('Turnstile verification error:', error);
-    return false;
-  }
-}
-
 export async function POST(req: NextRequest) {
   const {DIRECTUS_URL} = process.env;
   const DIRECTUS_TOKEN = process.env.DIRECTUS_STATIC_TOKEN;
@@ -31,27 +10,13 @@ export async function POST(req: NextRequest) {
 
   const payload = await req.json();
 
-  // Verify Turnstile token
-  const turnstileToken = payload.turnstile_token;
-  if (!turnstileToken) {
-    return NextResponse.json({ error: "Verification token missing" }, { status: 400 });
-  }
-
-  const isValid = await verifyTurnstileToken(turnstileToken);
-  if (!isValid) {
-    return NextResponse.json({ error: "Verification failed. Please try again." }, { status: 400 });
-  }
-
-  // Remove turnstile_token from payload before sending to Directus
-  const { turnstile_token, ...directusPayload } = payload;
-
   const res = await fetch(`${DIRECTUS_URL}/items/registrations`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "authorization": `Bearer ${DIRECTUS_TOKEN}`
     },
-    body: JSON.stringify(directusPayload),
+    body: JSON.stringify(payload),
   });
 
   if (!res.ok) {

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,21 +1,6 @@
 'use client';
 
-import { useState, useRef } from "react";
-import Script from "next/script";
-
-declare global {
-  interface Window {
-    turnstile?: {
-      render: (element: HTMLElement | string, options: {
-        sitekey: string;
-        callback?: (token: string) => void;
-        'error-callback'?: () => void;
-        'expired-callback'?: () => void;
-      }) => string;
-      reset: (widgetId?: string) => void;
-    };
-  }
-}
+import { useState } from "react";
 
 interface Child {
   full_name: string;
@@ -37,8 +22,6 @@ export default function RegisterPage() {
   const [marketing_opt_in, setOptIn] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [errorField, setErrorField] = useState<string | null>(null);
-  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
-  const turnstileRef = useRef<HTMLDivElement>(null);
 
   const weekdays = ["Mon","Tue","Wed","Thu","Fri"];
 
@@ -83,19 +66,12 @@ export default function RegisterPage() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-    // Only require token if Turnstile is configured
-    if (siteKey && !turnstileToken) {
-      setStatus("❌ Please complete the verification");
-      return;
-    }
     setStatus("Submitting...");
     setErrorField(null);
     try {
       // Map parents array to parent1_* and parent2_* fields
       const payload: Record<string, unknown> = {
         children, notes, marketing_opt_in,
-        turnstile_token: turnstileToken,
       };
 
       // Always include parent1 fields (at least one parent required)
@@ -127,44 +103,13 @@ export default function RegisterPage() {
       }
       setStatus("✅ Thanks! Your registration was received.");
       setErrorField(null);
-      setTurnstileToken(null);
-      // Reset Turnstile widget
-      if (window.turnstile) {
-        window.turnstile.reset();
-      }
     } catch (err:any) {
       setStatus("❌ " + err.message);
-      // Reset Turnstile on error
-      if (window.turnstile) {
-        window.turnstile.reset();
-        setTurnstileToken(null);
-      }
     }
   }
 
   return (
     <div className="space-y-6">
-      <Script
-        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
-        strategy="lazyOnload"
-        onLoad={() => {
-          const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-          if (window.turnstile && turnstileRef.current && siteKey) {
-            window.turnstile.render(turnstileRef.current, {
-              sitekey: siteKey,
-              callback: (token: string) => {
-                setTurnstileToken(token);
-              },
-              'error-callback': () => {
-                setTurnstileToken(null);
-              },
-              'expired-callback': () => {
-                setTurnstileToken(null);
-              },
-            });
-          }
-        }}
-      />
       <h1 className="text-3xl font-bold text-white">Registration</h1>
       <p className="text-white/90">Tell us about your family. You can add up to three kids.</p>
 
@@ -280,11 +225,6 @@ export default function RegisterPage() {
             />
             I agree to receive updates about the club.
           </label>
-        </div>
-
-        <div className="card">
-          <label className="label mb-2">Verification</label>
-          <div ref={turnstileRef}></div>
         </div>
 
         <div className="flex items-center gap-3">

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -19,10 +19,3 @@ jest.mock('next/navigation', () => ({
     return '/'
   },
 }))
-
-// Mock window.turnstile for tests
-global.window = global.window || {}
-global.window.turnstile = {
-  render: jest.fn(() => 'widget-id'),
-  reset: jest.fn(),
-}


### PR DESCRIPTION
This PR removes Cloudflare Turnstile verification from the registration form and related code.

## Changes

- Removed Turnstile verification logic from `/app/api/register/route.ts`
- Removed Turnstile widget and related code from `/app/register/page.tsx`
- Removed Turnstile-related tests from `__tests__/api/register/route.test.ts`
- Removed Turnstile mocks from `jest.setup.js`
- Updated documentation in `README.md` and `TESTING.md` to reflect removal

## Summary

- **Files changed**: 6 files
- **Lines removed**: ~261 lines
- **Lines added**: ~8 lines

The registration form will continue to work without bot protection. Consider adding alternative bot protection or rate limiting in the future.