### PR TITLE
Reduce footer margin from mt-16 to mt-4

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Navbar />
         </header>
         <main className="container py-10">{children}</main>
-        <footer className="border-t border-white/20 mt-16">
+        <footer className="border-t border-white/20 mt-4">
           <div className="container py-8 text-sm text-white/70">
             © {new Date().getFullYear()} Glenview Ultimate
           </div>


### PR DESCRIPTION
Reduces the footer top margin from `mt-16` (4rem/64px) to `mt-4` (1rem/16px) for tighter spacing between the main content and footer.