### PR TITLE
Link glenview-ultimate.org in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Skeyelab/glenview-ultimate/actions/workflows/ci.yml/badge.svg)](https://github.com/Skeyelab/glenview-ultimate/actions/workflows/ci.yml)
 
-A Next.js website for Glenview Ultimate, a youth ultimate frisbee organization. The site connects to a Directus CMS backend for content management and includes features for registration, news, schedules, and team information.
+A Next.js website for [Glenview Ultimate](https://glenview-ultimate.org), a youth ultimate frisbee organization. The site connects to a Directus CMS backend for content management and includes features for registration, news, schedules, and team information.
 
 ## Features
 


### PR DESCRIPTION
Add a link to glenview-ultimate.org on its first mention in the README.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b5b156c-eb73-4cf9-9f12-b8b22a63651e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b5b156c-eb73-4cf9-9f12-b8b22a63651e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

