### PR TITLE
Investigate build failure

### DIFF
--- a/lib/directus.ts
+++ b/lib/directus.ts
@@ -1,4 +1,4 @@
-import { createDirectus, createItem, readItems, readSingleton, rest, staticToken } from "@directus/sdk";
+import { createDirectus, createItem, readItems, rest, staticToken } from "@directus/sdk";
 import type { DirectusClient, RestClient, StaticTokenClient } from "@directus/sdk";
 import { safeParseDate } from "./date-utils";
 
@@ -316,11 +316,12 @@ export function getAbout(): Promise<About | null> {
 export function getWhatIsUltimate(): Promise<WhatIsUltimate | null> {
   return withDirectus<WhatIsUltimate | null>(null, async (client) => {
     const data = await client.request(
-      readSingleton("WhatIsUltimate", {
+      readItems("WhatIsUltimate", {
+        limit: 1,
         fields: ["*"],
       }),
     );
-    return data;
+    return data[0] ?? null;
   });
 }
 


### PR DESCRIPTION
Fixes build failure by changing `getWhatIsUltimate` to use `readItems` instead of `readSingleton`.

The `readSingleton` function was causing TypeScript type inference issues and was not correctly recognized in the schema, leading to a build failure. Switching to `readItems` with `limit: 1` resolves this issue and aligns with the pattern used for other singleton-like collections.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf36ee58-8e01-4815-aea2-a79b300f37d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf36ee58-8e01-4815-aea2-a79b300f37d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

