### PR TITLE
Update Team schema to support squad field

### DIFF
--- a/__tests__/components/about/role-utils.test.ts
+++ b/__tests__/components/about/role-utils.test.ts
@@ -1,0 +1,161 @@
+import {
+  normalizeRole,
+  getRoleDisplayTitle,
+  isLeadershipRole,
+  LEADERSHIP_ROLES,
+  type LeadershipRole,
+} from '@/components/about/role-utils';
+
+describe('role-utils', () => {
+  describe('normalizeRole', () => {
+    it('should normalize "captain" with squad="boys" to "boys_team_captain"', () => {
+      expect(normalizeRole('captain', 'boys')).toBe('boys_team_captain');
+    });
+
+    it('should normalize "Captain" with squad="boys" to "boys_team_captain"', () => {
+      expect(normalizeRole('Captain', 'boys')).toBe('boys_team_captain');
+    });
+
+    it('should normalize "captain" with squad="girls" to "girls_team_captain"', () => {
+      expect(normalizeRole('captain', 'girls')).toBe('girls_team_captain');
+    });
+
+    it('should normalize "captain" without squad to "captain"', () => {
+      expect(normalizeRole('captain')).toBe('captain');
+      expect(normalizeRole('captain', null)).toBe('captain');
+    });
+
+    it('should normalize "boys_team_captain" to "boys_team_captain"', () => {
+      expect(normalizeRole('boys_team_captain')).toBe('boys_team_captain');
+    });
+
+    it('should normalize "Boys Team Captain" to "boys_team_captain"', () => {
+      expect(normalizeRole('Boys Team Captain')).toBe('boys_team_captain');
+    });
+
+    it('should normalize "girls_team_captain" to "girls_team_captain"', () => {
+      expect(normalizeRole('girls_team_captain')).toBe('girls_team_captain');
+    });
+
+    it('should normalize "Girls Team Captain" to "girls_team_captain"', () => {
+      expect(normalizeRole('Girls Team Captain')).toBe('girls_team_captain');
+    });
+
+    it('should normalize "head_coach" to "head_coach"', () => {
+      expect(normalizeRole('head_coach')).toBe('head_coach');
+    });
+
+    it('should normalize "Head Coach" to "head_coach"', () => {
+      expect(normalizeRole('Head Coach')).toBe('head_coach');
+    });
+
+    it('should return original role if not recognized', () => {
+      expect(normalizeRole('player')).toBe('player');
+      expect(normalizeRole('unknown_role')).toBe('unknown_role');
+    });
+
+    it('should prioritize squad parameter over role value for captains', () => {
+      // Even if role is already a specific captain role, squad should be used
+      expect(normalizeRole('captain', 'boys')).toBe('boys_team_captain');
+      expect(normalizeRole('captain', 'girls')).toBe('girls_team_captain');
+    });
+  });
+
+  describe('getRoleDisplayTitle', () => {
+    it('should return "Boys Team Captain" for boys_team_captain', () => {
+      expect(getRoleDisplayTitle('boys_team_captain')).toBe('Boys Team Captain');
+    });
+
+    it('should return "Boys Team Captain" for "captain" with squad="boys"', () => {
+      expect(getRoleDisplayTitle('captain', 'boys')).toBe('Boys Team Captain');
+    });
+
+    it('should return "Girls Team Captain" for girls_team_captain', () => {
+      expect(getRoleDisplayTitle('girls_team_captain')).toBe('Girls Team Captain');
+    });
+
+    it('should return "Girls Team Captain" for "captain" with squad="girls"', () => {
+      expect(getRoleDisplayTitle('captain', 'girls')).toBe('Girls Team Captain');
+    });
+
+    it('should return "Head Coach" for head_coach', () => {
+      expect(getRoleDisplayTitle('head_coach')).toBe('Head Coach');
+    });
+
+    it('should return "Head Coach" for "Head Coach"', () => {
+      expect(getRoleDisplayTitle('Head Coach')).toBe('Head Coach');
+    });
+
+    it('should return original role if not recognized', () => {
+      expect(getRoleDisplayTitle('player')).toBe('player');
+      expect(getRoleDisplayTitle('unknown_role')).toBe('unknown_role');
+    });
+
+    it('should handle captain role without squad', () => {
+      expect(getRoleDisplayTitle('captain')).toBe('captain');
+      expect(getRoleDisplayTitle('captain', null)).toBe('captain');
+    });
+  });
+
+  describe('isLeadershipRole', () => {
+    it('should return true for "boys_team_captain"', () => {
+      expect(isLeadershipRole('boys_team_captain')).toBe(true);
+    });
+
+    it('should return true for "captain" with squad="boys"', () => {
+      expect(isLeadershipRole('captain', 'boys')).toBe(true);
+    });
+
+    it('should return true for "girls_team_captain"', () => {
+      expect(isLeadershipRole('girls_team_captain')).toBe(true);
+    });
+
+    it('should return true for "captain" with squad="girls"', () => {
+      expect(isLeadershipRole('captain', 'girls')).toBe(true);
+    });
+
+    it('should return true for "head_coach"', () => {
+      expect(isLeadershipRole('head_coach')).toBe(true);
+    });
+
+    it('should return true for "Head Coach"', () => {
+      expect(isLeadershipRole('Head Coach')).toBe(true);
+    });
+
+    it('should return false for non-leadership roles', () => {
+      expect(isLeadershipRole('player')).toBe(false);
+      expect(isLeadershipRole('assistant_coach')).toBe(false);
+      expect(isLeadershipRole('unknown_role')).toBe(false);
+    });
+
+    it('should return false for "captain" without squad', () => {
+      expect(isLeadershipRole('captain')).toBe(false);
+      expect(isLeadershipRole('captain', null)).toBe(false);
+    });
+
+    it('should have correct type guard behavior', () => {
+      const role1 = 'boys_team_captain';
+      if (isLeadershipRole(role1)) {
+        const typed: LeadershipRole = role1; // TypeScript should accept this
+        expect(LEADERSHIP_ROLES).toContain(typed);
+      }
+
+      const role2 = 'captain';
+      if (isLeadershipRole(role2, 'boys')) {
+        const typed: LeadershipRole = normalizeRole(role2, 'boys') as LeadershipRole;
+        expect(LEADERSHIP_ROLES).toContain(typed);
+      }
+    });
+  });
+
+  describe('LEADERSHIP_ROLES constant', () => {
+    it('should contain expected leadership roles', () => {
+      expect(LEADERSHIP_ROLES).toEqual(['boys_team_captain', 'girls_team_captain', 'head_coach']);
+    });
+
+    it('should have correct length', () => {
+      expect(LEADERSHIP_ROLES).toHaveLength(3);
+    });
+  });
+});
+

--- a/components/about/role-utils.ts
+++ b/components/about/role-utils.ts
@@ -1,4 +1,12 @@
-export function normalizeRole(role: string): string {
+export function normalizeRole(role: string, squad?: string | null): string {
+  // Handle "captain" role with squad field
+  if (role === "captain" || role === "Captain") {
+    if (squad === "boys") return "boys_team_captain";
+    if (squad === "girls") return "girls_team_captain";
+    // Fallback if squad is missing - try to infer from role display text
+    return role;
+  }
+
   // Handle both display text and value formats
   const roleMap: Record<string, string> = {
     "boys_team_captain": "boys_team_captain",
@@ -11,8 +19,8 @@ export function normalizeRole(role: string): string {
   return roleMap[role] ?? role;
 }
 
-export function getRoleDisplayTitle(role: string): string {
-  const normalized = normalizeRole(role);
+export function getRoleDisplayTitle(role: string, squad?: string | null): string {
+  const normalized = normalizeRole(role, squad);
   switch (normalized) {
     case "boys_team_captain":
       return "Boys Team Captain";
@@ -29,6 +37,6 @@ export const LEADERSHIP_ROLES = ["boys_team_captain", "girls_team_captain", "hea
 
 export type LeadershipRole = (typeof LEADERSHIP_ROLES)[number];
 
-export function isLeadershipRole(role: string): role is LeadershipRole {
-  return LEADERSHIP_ROLES.includes(normalizeRole(role) as LeadershipRole);
+export function isLeadershipRole(role: string, squad?: string | null): role is LeadershipRole {
+  return LEADERSHIP_ROLES.includes(normalizeRole(role, squad) as LeadershipRole);
 }

--- a/components/about/team-leadership-section.tsx
+++ b/components/about/team-leadership-section.tsx
@@ -23,24 +23,24 @@ export function TeamLeadershipSection({
 }: TeamLeadershipSectionProps): React.JSX.Element {
   const leadershipRoles = ["boys_team_captain", "girls_team_captain", "head_coach"];
   const allLeadershipMembers = members.filter((member) => {
-    const normalizedRole = normalizeRole(member.role);
+    const normalizedRole = normalizeRole(member.role, member.squad);
     return leadershipRoles.includes(normalizedRole);
   });
 
   // Separate captains and coach
   const captains = allLeadershipMembers
     .filter((member) => {
-      const normalizedRole = normalizeRole(member.role);
+      const normalizedRole = normalizeRole(member.role, member.squad);
       return normalizedRole === "boys_team_captain" || normalizedRole === "girls_team_captain";
     })
     .sort((a, b) => {
-      const normalizedA = normalizeRole(a.role);
-      const normalizedB = normalizeRole(b.role);
+      const normalizedA = normalizeRole(a.role, a.squad);
+      const normalizedB = normalizeRole(b.role, b.squad);
       return captainOrder.indexOf(normalizedA) - captainOrder.indexOf(normalizedB);
     });
 
   const coach = allLeadershipMembers.find((member) => {
-    const normalizedRole = normalizeRole(member.role);
+    const normalizedRole = normalizeRole(member.role, member.squad);
     return normalizedRole === "head_coach";
   });
 

--- a/components/about/team-member-card.tsx
+++ b/components/about/team-member-card.tsx
@@ -23,8 +23,8 @@ export function TeamMemberCard({
   className,
 }: TeamMemberCardProps): React.JSX.Element {
   const photoUrl = getDirectusAssetUrl(member.photo);
-  const roleTitle = getRoleDisplayTitle(member.role);
-  const normalizedRole = normalizeRole(member.role);
+  const roleTitle = getRoleDisplayTitle(member.role, member.squad);
+  const normalizedRole = normalizeRole(member.role, member.squad);
   const isHeadCoach = normalizedRole === "head_coach";
   const shouldSpanFull = spanFullWidth || isHeadCoach;
 

--- a/lib/directus.ts
+++ b/lib/directus.ts
@@ -16,6 +16,7 @@ export interface TeamMember {
   email?: string | null;
   bio?: string | null;
   photo?: string | null;
+  squad?: string | null;
 }
 
 export type ScheduleEventType =


### PR DESCRIPTION
## Summary

This PR updates the codebase to support the new Team collection schema in Directus, which introduces a `squad` field and uses simplified role values.

## Changes

### Schema Updates
- Added `squad?: string | null` field to `TeamMember` interface
- Supports new schema where:
  - Role can be `"captain"` (instead of `"boys_team_captain"`/`"girls_team_captain"`), with `squad` indicating the team
  - Role can be `"Head Coach"` (instead of `"head_coach"`)
  - New `squad` field: `"boys"`, `"girls"`, or `null`

### Code Updates
- **`lib/directus.ts`**: Added `squad` field to `TeamMember` interface
- **`components/about/role-utils.ts`**: 
  - Updated `normalizeRole()` to accept optional `squad` parameter
  - Normalizes `"captain"` + `squad: "boys"` → `"boys_team_captain"`
  - Normalizes `"captain"` + `squad: "girls"` → `"girls_team_captain"`
  - Normalizes `"Head Coach"` → `"head_coach"`
  - Updated `getRoleDisplayTitle()` and `isLeadershipRole()` to accept `squad`
- **`components/about/team-leadership-section.tsx`**: Updated to pass `member.squad` when filtering and sorting leadership members
- **`components/about/team-member-card.tsx`**: Updated to pass `member.squad` when normalizing roles

### Testing
- Added comprehensive test suite for `role-utils.ts` with 31 new tests
- All tests cover:
  - Role normalization with and without squad parameter
  - Display title generation
  - Leadership role detection
  - Edge cases and backward compatibility

## Test Results
- ✅ All 246 tests passing (31 new tests added)
- ✅ Lint passing
- ✅ TypeScript compilation successful

## Backward Compatibility
The code maintains backward compatibility with old role values (`"boys_team_captain"`, `"girls_team_captain"`, `"head_coach"`) while supporting the new schema structure.