### PR TITLE
Extract TeamMemberCard to shared UI component with spacing variants

### DIFF
--- a/__tests__/components/home/leadership-section.test.tsx
+++ b/__tests__/components/home/leadership-section.test.tsx
@@ -10,6 +10,36 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
+// Mock next/image
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ src, alt, ...props }: { src: string; alt: string; [key: string]: any }) => {
+    const { width: _width, height: _height, className: _className, onError: _onError, ...htmlProps } = props;
+    return <img src={src} alt={alt} {...htmlProps} />;
+  },
+}));
+
+// Mock directus functions
+vi.mock('@/lib/directus', () => ({
+  getDirectusAssetUrl: vi.fn((id: string | null) => (id ? `/api/assets/${id}` : null)),
+}));
+
+// Mock role-utils
+vi.mock('@/components/about/role-utils', () => ({
+  normalizeRole: vi.fn((role: string, squad?: string | null) => {
+    if (role === 'captain' && squad === 'boys') return 'boys_team_captain';
+    if (role === 'captain' && squad === 'girls') return 'girls_team_captain';
+    if (role === 'Head Coach' || role === 'head_coach') return 'head_coach';
+    return role;
+  }),
+  getRoleDisplayTitle: vi.fn((role: string, squad?: string | null) => {
+    if (role === 'boys_team_captain' || (role === 'captain' && squad === 'boys')) return 'Boys Team Captain';
+    if (role === 'girls_team_captain' || (role === 'captain' && squad === 'girls')) return 'Girls Team Captain';
+    if (role === 'head_coach' || role === 'Head Coach') return 'Head Coach';
+    return role;
+  }),
+}));
+
 describe('LeadershipSection', () => {
   const mockTeamMember1: TeamMember = {
     id: 1,
@@ -18,6 +48,7 @@ describe('LeadershipSection', () => {
     email: 'john@example.com',
     bio: null,
     photo: null,
+    squad: null,
   };
 
   const mockTeamMember2: TeamMember = {
@@ -27,6 +58,7 @@ describe('LeadershipSection', () => {
     email: 'jane@example.com',
     bio: null,
     photo: null,
+    squad: null,
   };
 
   const mockTeamMemberWithoutEmail: TeamMember = {
@@ -36,6 +68,7 @@ describe('LeadershipSection', () => {
     email: null,
     bio: null,
     photo: null,
+    squad: null,
   };
 
   it('renders the section title', () => {
@@ -62,6 +95,31 @@ describe('LeadershipSection', () => {
     render(<LeadershipSection people={[mockTeamMember1]} />);
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('Head Coach')).toBeInTheDocument();
+  });
+
+  it('uses TeamMemberCard with compact spacing on homepage', () => {
+    const { container } = render(<LeadershipSection people={[mockTeamMember1]} />);
+    // Find the flex container inside the TeamMemberCard (not the SectionCard)
+    // Look for the card that contains the member name
+    const memberName = screen.getByText('John Doe');
+    const card = memberName.closest('.card');
+    const flexContainer = card?.querySelector('.flex');
+    expect(flexContainer).toHaveClass('gap-2');
+  });
+
+  it('hides bio on homepage', () => {
+    const memberWithBio: TeamMember = {
+      ...mockTeamMember1,
+      bio: 'Test bio',
+    };
+    render(<LeadershipSection people={[memberWithBio]} />);
+    expect(screen.queryByText('Test bio')).not.toBeInTheDocument();
+  });
+
+  it('uses square images on homepage', () => {
+    const { container } = render(<LeadershipSection people={[mockTeamMember1]} />);
+    const imageContainer = container.querySelector('.flex-shrink-0');
+    expect(imageContainer).toHaveClass('w-32', 'h-32');
   });
 
   it('renders email link when email is provided', () => {

--- a/__tests__/components/ui/team-member-card.test.tsx
+++ b/__tests__/components/ui/team-member-card.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { TeamMemberCard } from '@/components/ui/team-member-card';
+import type { TeamMember } from '@/lib/directus';
+
+// Mock next/image
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ src, alt, ...props }: { src: string; alt: string; [key: string]: any }) => {
+    const { width: _width, height: _height, className: _className, onError: _onError, ...htmlProps } = props;
+    return <img src={src} alt={alt} {...htmlProps} />;
+  },
+}));
+
+// Mock directus functions
+vi.mock('@/lib/directus', () => ({
+  getDirectusAssetUrl: vi.fn((id: string | null) => (id ? `/api/assets/${id}` : null)),
+}));
+
+// Mock role-utils
+vi.mock('@/components/about/role-utils', () => ({
+  normalizeRole: vi.fn((role: string, squad?: string | null) => {
+    if (role === 'captain' && squad === 'boys') return 'boys_team_captain';
+    if (role === 'captain' && squad === 'girls') return 'girls_team_captain';
+    if (role === 'Head Coach' || role === 'head_coach') return 'head_coach';
+    return role;
+  }),
+  getRoleDisplayTitle: vi.fn((role: string, squad?: string | null) => {
+    if (role === 'boys_team_captain' || (role === 'captain' && squad === 'boys')) return 'Boys Team Captain';
+    if (role === 'girls_team_captain' || (role === 'captain' && squad === 'girls')) return 'Girls Team Captain';
+    if (role === 'head_coach' || role === 'Head Coach') return 'Head Coach';
+    return role;
+  }),
+}));
+
+describe('TeamMemberCard', () => {
+  const mockTeamMember: TeamMember = {
+    id: 1,
+    name: 'John Doe',
+    role: 'Head Coach',
+    email: 'john@example.com',
+    bio: 'Test bio',
+    photo: 'photo-id',
+    squad: null,
+  };
+
+  const mockTeamMemberWithoutPhoto: TeamMember = {
+    id: 2,
+    name: 'Jane Smith',
+    role: 'captain',
+    email: 'jane@example.com',
+    bio: null,
+    photo: null,
+    squad: 'boys',
+  };
+
+  const mockTeamMemberWithoutEmail: TeamMember = {
+    id: 3,
+    name: 'Bob Johnson',
+    role: 'Assistant Coach',
+    email: null,
+    bio: 'Some bio',
+    photo: 'photo-id-2',
+    squad: null,
+  };
+
+  it('renders member name and role', () => {
+    render(<TeamMemberCard member={mockTeamMember} />);
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Head Coach')).toBeInTheDocument();
+  });
+
+  it('renders email link when email is provided and showEmail is true', () => {
+    render(<TeamMemberCard member={mockTeamMember} />);
+    const emailLink = screen.getByRole('link', { name: 'john@example.com' });
+    expect(emailLink).toBeInTheDocument();
+    expect(emailLink).toHaveAttribute('href', 'mailto:john@example.com');
+  });
+
+  it('does not render email when showEmail is false', () => {
+    render(<TeamMemberCard member={mockTeamMember} showEmail={false} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('does not render email when email is null', () => {
+    render(<TeamMemberCard member={mockTeamMemberWithoutEmail} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders bio when bio is provided and showBio is true', () => {
+    render(<TeamMemberCard member={mockTeamMember} />);
+    expect(screen.getByText('Test bio')).toBeInTheDocument();
+  });
+
+  it('does not render bio when showBio is false', () => {
+    render(<TeamMemberCard member={mockTeamMember} showBio={false} />);
+    expect(screen.queryByText('Test bio')).not.toBeInTheDocument();
+  });
+
+  it('renders photo when photo is provided', () => {
+    render(<TeamMemberCard member={mockTeamMember} />);
+    const image = screen.getByAltText('John Doe');
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', '/api/assets/photo-id');
+  });
+
+  it('renders placeholder text when photo is not provided', () => {
+    render(<TeamMemberCard member={mockTeamMemberWithoutPhoto} />);
+    expect(screen.getByText('Photo coming soon')).toBeInTheDocument();
+  });
+
+  it('applies card class', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} />);
+    const card = container.querySelector('.card');
+    expect(card).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} className="custom-class" />);
+    const card = container.querySelector('.card');
+    expect(card).toHaveClass('custom-class');
+  });
+
+  it('spans full width when spanFullWidth is true', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} spanFullWidth={true} />);
+    const card = container.querySelector('.card');
+    expect(card).toHaveClass('md:col-span-2');
+  });
+
+  it('spans full width when member is head coach', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} />);
+    const card = container.querySelector('.card');
+    expect(card).toHaveClass('md:col-span-2');
+  });
+
+  it('uses compact internal gap when internalGap is compact', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} internalGap="compact" />);
+    const flexContainer = container.querySelector('.flex');
+    expect(flexContainer).toHaveClass('gap-2');
+  });
+
+  it('uses normal internal gap by default', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} />);
+    const flexContainer = container.querySelector('.flex');
+    expect(flexContainer).toHaveClass('gap-4');
+  });
+
+  it('uses square image dimensions when squareImage is true', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} squareImage={true} />);
+    const imageContainer = container.querySelector('.flex-shrink-0');
+    expect(imageContainer).toHaveClass('w-32', 'h-32');
+    expect(imageContainer).not.toHaveClass('w-52', 'h-64');
+  });
+
+  it('uses rectangular image dimensions by default', () => {
+    const { container } = render(<TeamMemberCard member={mockTeamMember} />);
+    const imageContainer = container.querySelector('.flex-shrink-0');
+    expect(imageContainer).toHaveClass('w-52', 'h-64');
+    expect(imageContainer).not.toHaveClass('w-32', 'h-32');
+  });
+
+  it('passes through HTML attributes', () => {
+    const { container } = render(
+      <TeamMemberCard member={mockTeamMember} data-testid="test-card" data-directus="test" />
+    );
+    const card = container.querySelector('[data-testid="test-card"]');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute('data-directus', 'test');
+  });
+});
+

--- a/components/about/team-leadership-section.tsx
+++ b/components/about/team-leadership-section.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { TeamMember } from "@/lib/directus";
 import { cn } from "@/lib/utils";
 import { normalizeRole } from "./role-utils";
-import { TeamMemberCard } from "./team-member-card";
+import { TeamMemberCard } from "@/components/ui/team-member-card";
 
 export interface TeamLeadershipSectionProps {
   members: TeamMember[];

--- a/components/home/leadership-section.tsx
+++ b/components/home/leadership-section.tsx
@@ -4,6 +4,7 @@ import type { TeamMember } from "@/lib/directus";
 import { useSearchParams } from "next/navigation";
 import { setAttr } from "@/lib/visual-editing";
 import { SectionCard } from "@/components/ui/section-card";
+import { TeamMemberCard } from "@/components/ui/team-member-card";
 
 export interface LeadershipSectionProps {
   people: TeamMember[];
@@ -29,24 +30,15 @@ export function LeadershipSection({
           people.map((p) => (
             <React.Fragment key={p.id}>
               {renderMember?.(p) ?? (
-                <div
-                  className="border border-white/20 rounded p-2"
+                <TeamMemberCard
+                  member={p}
+                  internalGap="compact"
+                  showBio={false}
+                  squareImage={true}
                   {...(editingEnabled
                     ? { "data-directus": setAttr({ collection: "Team", item: p.id, fields: ["name", "role", "email"], mode: "popover" }) }
                     : {})}
-                >
-                  <div className="font-medium text-white">
-                    {p.name}
-                  </div>
-                  <div className="text-sm text-white/70">
-                    {p.role}
-                  </div>
-                  {p.email && (
-                    <a className="text-sm text-white/80 hover:text-white" href={`mailto:${p.email}`}>
-                      {p.email}
-                    </a>
-                  )}
-                </div>
+                />
               )}
             </React.Fragment>
           ))

--- a/components/ui/team-member-card.tsx
+++ b/components/ui/team-member-card.tsx
@@ -4,16 +4,17 @@ import React, { useState } from "react";
 import Image from "next/image";
 import type { TeamMember } from "@/lib/directus";
 import { getDirectusAssetUrl } from "@/lib/directus";
-import { normalizeRole, getRoleDisplayTitle } from "./role-utils";
+import { normalizeRole, getRoleDisplayTitle } from "@/components/about/role-utils";
 import { cn } from "@/lib/utils";
 
-export interface TeamMemberCardProps {
+export interface TeamMemberCardProps extends React.HTMLAttributes<HTMLDivElement> {
   member: TeamMember;
   spanFullWidth?: boolean;
   photoHeight?: string;
   showEmail?: boolean;
   showBio?: boolean;
-  className?: string;
+  internalGap?: "compact" | "normal";
+  squareImage?: boolean;
 }
 
 export function TeamMemberCard({
@@ -22,6 +23,9 @@ export function TeamMemberCard({
   showEmail = true,
   showBio = true,
   className,
+  internalGap = "normal",
+  squareImage = false,
+  ...props
 }: TeamMemberCardProps): React.JSX.Element {
   const photoUrl = getDirectusAssetUrl(member.photo);
   const roleTitle = getRoleDisplayTitle(member.role, member.squad);
@@ -30,11 +34,16 @@ export function TeamMemberCard({
   const shouldSpanFull = spanFullWidth || isHeadCoach;
   const [imageError, setImageError] = useState(false);
 
+  const gapClass = internalGap === "compact" ? "gap-2" : "gap-4";
+  const imageContainerClass = squareImage
+    ? "flex-shrink-0 w-32 h-32 rounded-lg bg-white/10 flex items-center justify-center overflow-hidden"
+    : "flex-shrink-0 w-52 h-64 rounded-lg bg-white/10 flex items-center justify-center overflow-hidden";
+
   return (
-    <div className={cn("card", shouldSpanFull && "md:col-span-2", className)}>
-      <div className="flex gap-4">
+    <div className={cn("card", shouldSpanFull && "md:col-span-2", className)} {...props}>
+      <div className={cn("flex", gapClass)}>
         {/* Photo on the left */}
-        <div className="flex-shrink-0 w-52 h-64 aspect-square rounded-lg bg-white/10 flex items-center justify-center overflow-hidden">
+        <div className={imageContainerClass}>
           {photoUrl && !imageError ? (
             <Image
               src={photoUrl}
@@ -70,3 +79,4 @@ export function TeamMemberCard({
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary

Extracts `TeamMemberCard` from `components/about/` to `components/ui/` to make it reusable across the application, and adds spacing variant props for flexible styling.

## Changes

- **Moved component**: `components/about/team-member-card.tsx` → `components/ui/team-member-card.tsx`
- **Added `internalGap` prop**: Controls spacing between photo and info (`"compact"` → `gap-2`, `"normal"` → `gap-4`)
- **Added `squareImage` prop**: Controls image dimensions (`true` → `w-32 h-32`, `false` → `w-52 h-64`)
- **Updated `LeadershipSection`**: Now uses `TeamMemberCard` with compact spacing and square images for homepage
- **Updated `TeamLeadershipSection`**: Updated import to use new location
- **Added comprehensive tests**: 17 new tests for `TeamMemberCard` covering all props and variants
- **Updated `LeadershipSection` tests**: Added tests for homepage-specific behavior

## Testing

- ✅ All 266 tests passing
- ✅ Lint passes with no errors
- ✅ Build completes successfully

## Usage

The component now supports different spacing variants:

```tsx
// Homepage (compact spacing, square images)
<TeamMemberCard member={member} internalGap="compact" squareImage={true} showBio={false} />

// About page (normal spacing, rectangular images)
<TeamMemberCard member={member} />
```