### PR TITLE
feat: migrate hero section to use hero_block rich text field

### DIFF
--- a/__tests__/components/home/hero-section.test.tsx
+++ b/__tests__/components/home/hero-section.test.tsx
@@ -3,12 +3,17 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { HeroSection } from '@/components/home/hero-section';
-import type { SeasonSchedule } from '@/lib/directus';
-import { HERO_CTA_LABEL, HERO_CTA_URL, HERO_PRE_REGISTRATION_TEXT } from '@/lib/constants';
+import type { SeasonSchedule, Website } from '@/lib/directus';
+import { HERO_CTA_LABEL, HERO_CTA_URL, HERO_PRE_REGISTRATION_TEXT, HERO_BLOCK } from '@/lib/constants';
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock sanitize-html
+vi.mock('sanitize-html', () => ({
+  default: vi.fn((html: string) => html),
 }));
 
 // Mock next/image
@@ -47,12 +52,48 @@ describe('HeroSection', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/The Fun Starts/i);
   });
 
-  it('renders hero paragraphs', () => {
-    render(<HeroSection season={null} logoUrl={null} website={null} />);
+  it('renders hero block HTML content when provided', () => {
+    const mockWebsite: Website = {
+      id: 1,
+      site_name: 'Glenview Ultimate',
+      hero_title: 'The Fun Starts - Spring 2026',
+      hero_block: '<p>Introducing Glenview\'s very first Youth Ultimate Frisbee Club</p><p>5th-8th Grade. Boys &amp; Girls.</p><p>Everyone is Welcome. Everyone Plays.</p><p>Come play with us. Join our team.</p>',
+    };
+    const { container } = render(<HeroSection season={null} logoUrl={null} website={mockWebsite} />);
     expect(screen.getByText(/Introducing Glenview's very first Youth Ultimate Frisbee Club/i)).toBeInTheDocument();
     expect(screen.getByText(/5th-8th Grade. Boys & Girls./i)).toBeInTheDocument();
     expect(screen.getByText(/Everyone is Welcome. Everyone Plays./i)).toBeInTheDocument();
     expect(screen.getByText(/Come play with us. Join our team./i)).toBeInTheDocument();
+  });
+
+  it('renders fallback hero block when website hero_block is null', () => {
+    const mockWebsite: Website = {
+      id: 1,
+      site_name: 'Glenview Ultimate',
+      hero_title: 'The Fun Starts - Spring 2026',
+      hero_block: null,
+    };
+    const { container } = render(<HeroSection season={null} logoUrl={null} website={mockWebsite} />);
+    const heroBlockDiv = container.querySelector('.prose');
+    expect(heroBlockDiv).toBeInTheDocument();
+    expect(screen.getByText(/Introducing Glenview's very first Youth Ultimate Frisbee Club/i)).toBeInTheDocument();
+  });
+
+  it('renders fallback hero block when website is null', () => {
+    render(<HeroSection season={null} logoUrl={null} website={null} />);
+    expect(screen.getByText(/Introducing Glenview's very first Youth Ultimate Frisbee Club/i)).toBeInTheDocument();
+  });
+
+  it('sanitizes hero block HTML content', async () => {
+    const sanitizeHtml = (await import('sanitize-html')).default;
+    const mockWebsite: Website = {
+      id: 1,
+      site_name: 'Glenview Ultimate',
+      hero_title: 'The Fun Starts - Spring 2026',
+      hero_block: '<p>Content</p><script>alert("xss")</script>',
+    };
+    render(<HeroSection season={null} logoUrl={null} website={mockWebsite} />);
+    expect(sanitizeHtml).toHaveBeenCalledWith(mockWebsite.hero_block);
   });
 
   it('renders the CTA link', () => {

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -6,12 +6,10 @@ import type { SeasonSchedule, Website } from "@/lib/directus";
 import { cn } from "@/lib/utils";
 import { useSearchParams } from "next/navigation";
 import { setAttr } from "@/lib/visual-editing";
+import sanitizeHtml from "sanitize-html";
 import {
   HERO_TITLE,
-  HERO_SUBTITLE,
-  HERO_TAGLINE,
-  HERO_MESSAGE_1,
-  HERO_MESSAGE_2,
+  HERO_BLOCK,
   HERO_CTA_LABEL,
   HERO_CTA_URL,
   HERO_PRE_REGISTRATION_TEXT,
@@ -29,16 +27,12 @@ export function HeroSection({ season, logoUrl, website, className }: HeroSection
   const editingEnabled = search.get("visual-editing") === "true";
 
   const heroTitle = website?.hero_title ?? HERO_TITLE;
-  const heroSubtitle = website?.hero_subtitle ?? HERO_SUBTITLE;
-  const heroTagline = website?.hero_tagline ?? HERO_TAGLINE;
-  const heroMessage1 = website?.hero_message_primary ?? HERO_MESSAGE_1;
-  const heroMessage2 = website?.hero_message_secondary ?? HERO_MESSAGE_2;
+  const heroBlock = website?.hero_block ?? HERO_BLOCK;
   const heroCtaLabel = website?.hero_cta_label ?? HERO_CTA_LABEL;
   const heroCtaUrl = website?.hero_cta_url ?? HERO_CTA_URL;
   const heroPreRegistrationText = website?.hero_pre_registration_text ?? HERO_PRE_REGISTRATION_TEXT;
 
-  const heroParagraphs = [heroSubtitle, heroTagline, heroMessage1, heroMessage2].filter(Boolean);
-  const heroParagraphClass = "text-lg text-white/90 max-w-2xl mx-auto";
+  const sanitizedHeroBlock = heroBlock ? sanitizeHtml(heroBlock) : null;
   const seasonLabel = season?.title ?? (season ? `${season.year} Season` : null);
 
   return (
@@ -51,10 +45,7 @@ export function HeroSection({ season, logoUrl, website, className }: HeroSection
               item: "home",
               fields: [
                 "hero_title",
-                "hero_subtitle",
-                "hero_tagline",
-                "hero_message_primary",
-                "hero_message_secondary",
+                "hero_block",
                 "hero_cta_label",
                 "hero_cta_url",
                 "hero_pre_registration_text",
@@ -91,24 +82,22 @@ export function HeroSection({ season, logoUrl, website, className }: HeroSection
       >
         {heroTitle}
       </h1>
-      {heroParagraphs.map((paragraph, index) => (
-        <p
-          key={`${paragraph}-${index}`}
-          className={heroParagraphClass}
+      {sanitizedHeroBlock && (
+        <div
+          className="text-lg text-white/90 max-w-2xl mx-auto prose prose-invert"
+          dangerouslySetInnerHTML={{ __html: sanitizedHeroBlock }}
           {...(editingEnabled
             ? {
                 "data-directus": setAttr({
                   collection: "Website",
                   item: "home",
-                  fields: ["hero_subtitle", "hero_tagline", "hero_message_primary", "hero_message_secondary"],
+                  fields: ["hero_block"],
                   mode: "popover",
                 }),
               }
             : {})}
-        >
-          {paragraph}
-        </p>
-      ))}
+        />
+      )}
       <div className="mt-4">
         <Link
           className="button"

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,10 +20,10 @@ export const DESCRIPTION_PARAGRAPHS = [
  * These may be removed in a future version once CMS migration is complete.
  */
 export const HERO_TITLE = "The Fun Starts - Spring 2026";
-export const HERO_SUBTITLE = "Introducing Glenview's very first Youth Ultimate Frisbee Club";
-export const HERO_TAGLINE = "5th-8th Grade. Boys & Girls.";
-export const HERO_MESSAGE_1 = "Everyone is Welcome. Everyone Plays.";
-export const HERO_MESSAGE_2 = "Come play with us. Join our team.";
+export const HERO_BLOCK = `<p>Introducing Glenview's very first Youth Ultimate Frisbee Club</p>
+<p>5th-8th Grade. Boys &amp; Girls.</p>
+<p>Everyone is Welcome. Everyone Plays.</p>
+<p>Come play with us. Join our team.</p>`;
 export const HERO_CTA_LABEL = "Register";
 export const HERO_CTA_URL = "/register";
 export const HERO_PRE_REGISTRATION_TEXT = "Pre-Registration is now open";

--- a/lib/directus.ts
+++ b/lib/directus.ts
@@ -85,10 +85,7 @@ export interface Website {
   id: number;
   site_name: string;
   hero_title: string;
-  hero_subtitle?: string | null;
-  hero_tagline?: string | null;
-  hero_message_primary?: string | null;
-  hero_message_secondary?: string | null;
+  hero_block?: string | null;
   hero_cta_label?: string | null;
   hero_cta_url?: string | null;
   hero_pre_registration_text?: string | null;
@@ -358,21 +355,14 @@ export function getWebsite(): Promise<Website | null> {
     const data = await client.request(
       readItems("Website", {
         limit: 1,
-        fields: [
-          "id",
-          "site_name",
-          "hero_title",
-          "hero_subtitle",
-          "hero_tagline",
-          "hero_message_primary",
-          "hero_message_secondary",
-          "hero_cta_label",
-          "hero_cta_url",
-          "hero_pre_registration_text",
-        ],
+        fields: ["*"],
       }),
     );
-    return data[0] ?? null;
+    // Website is a singleton collection, so data could be an array or a single object
+    if (Array.isArray(data)) {
+      return data[0] ?? null;
+    }
+    return data ?? null;
   });
 }
 


### PR DESCRIPTION
## Summary

Migrates the hero section from using four individual text fields (`hero_subtitle`, `hero_tagline`, `hero_message_primary`, `hero_message_secondary`) to a single rich text `hero_block` field, providing more flexible content management in Directus.

## Changes

### Code Changes
- **`lib/directus.ts`**
  - Updated `Website` interface to use `hero_block` instead of four individual fields
  - Fixed `getWebsite()` to handle singleton collections (returns object directly, not array)
  
- **`components/home/hero-section.tsx`**
  - Added `sanitize-html` import for HTML sanitization
  - Replaced `heroParagraphs` array rendering with single `dangerouslySetInnerHTML` div for `hero_block`
  - Updated visual editing attributes to reference `hero_block`

- **`lib/constants.ts`**
  - Removed deprecated individual constants
  - Added `HERO_BLOCK` constant as fallback when CMS data unavailable

### Directus CMS Changes
- Unhid `hero_block` field
- Hid deprecated individual fields (`hero_subtitle`, `hero_tagline`, `hero_message_primary`, `hero_message_secondary`)

### Tests
- Updated hero-section tests for new `hero_block` behavior
- Added fallback behavior tests
- All 529 tests passing

## Testing
- [x] `yarn test` - 529 tests pass
- [x] `yarn lint` - No errors
- [x] `yarn build` - Build successful
- [x] Verified hero_block content displays correctly in browser