### PR TITLE
Hide news nav link when no articles, remove emails from leadership cards, remove leadership section from homepage

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -6,7 +6,6 @@ import HomePage from '@/app/page';
 // Mock directus functions
 vi.mock('@/lib/directus', () => ({
   getPartners: vi.fn(),
-  getTeam: vi.fn(),
   getSchedule: vi.fn(),
   getWebsite: vi.fn(),
   getDirectusAssetUrl: vi.fn((id, options) => {
@@ -30,10 +29,6 @@ vi.mock('@/components/home/season-highlights-card', () => ({
   ),
 }));
 
-vi.mock('@/components/home/leadership-section', () => ({
-  LeadershipSection: ({ people }: any) => <div data-testid="leadership">{people?.length || 0} people</div>,
-}));
-
 vi.mock('@/components/home/partners-section', () => ({
   PartnersSection: ({ partners }: any) => <div data-testid="partners">{partners?.length || 0} partners</div>,
 }));
@@ -43,12 +38,11 @@ vi.mock('@/components/home/home-visual-editing-provider', () => ({
 }));
 
 describe('HomePage', () => {
-  let getPartners: any, getTeam: any, getSchedule: any, getWebsite: any, getDirectusAssetUrl: any;
+  let getPartners: any, getSchedule: any, getWebsite: any, getDirectusAssetUrl: any;
 
   beforeEach(async () => {
     const directus = await import('@/lib/directus');
     getPartners = directus.getPartners;
-    getTeam = directus.getTeam;
     getSchedule = directus.getSchedule;
     getWebsite = directus.getWebsite;
     getDirectusAssetUrl = directus.getDirectusAssetUrl;
@@ -61,7 +55,6 @@ describe('HomePage', () => {
 
   it('should render with empty data', async () => {
     getPartners.mockResolvedValue([]);
-    getTeam.mockResolvedValue([]);
     getSchedule.mockResolvedValue(null);
     getWebsite.mockResolvedValue(null);
 
@@ -70,20 +63,17 @@ describe('HomePage', () => {
 
     expect(getByTestId('hero-section')).toBeInTheDocument();
     expect(getByTestId('season-highlights')).toHaveTextContent('0 highlights');
-    expect(getByTestId('leadership')).toHaveTextContent('0 people');
     expect(getByTestId('partners')).toHaveTextContent('0 partners');
   });
 
   it('should render with fetched data', async () => {
     const mockPartners = [{ id: '1', name: 'Partner 1' }];
-    const mockTeam = [{ id: '1', name: 'Person 1' }];
     const mockSchedule = {
       highlights: [{ id: '1', title: 'Highlight 1' }],
     };
     const mockWebsite = { id: 1, hero_title: 'Test Title' };
 
     getPartners.mockResolvedValue(mockPartners);
-    getTeam.mockResolvedValue(mockTeam);
     getSchedule.mockResolvedValue(mockSchedule);
     getWebsite.mockResolvedValue(mockWebsite);
 
@@ -91,27 +81,23 @@ describe('HomePage', () => {
     const { getByTestId } = render(page);
 
     expect(getByTestId('partners')).toHaveTextContent('1 partners');
-    expect(getByTestId('leadership')).toHaveTextContent('1 people');
     expect(getByTestId('season-highlights')).toHaveTextContent('1 highlights');
   });
 
   it('should fetch all required data', async () => {
     getPartners.mockResolvedValue([]);
-    getTeam.mockResolvedValue([]);
     getSchedule.mockResolvedValue(null);
     getWebsite.mockResolvedValue(null);
 
     await HomePage();
 
     expect(getPartners).toHaveBeenCalledTimes(1);
-    expect(getTeam).toHaveBeenCalledTimes(1);
     expect(getSchedule).toHaveBeenCalledTimes(1);
     expect(getWebsite).toHaveBeenCalledTimes(1);
   });
 
   it('should get logo URL', async () => {
     getPartners.mockResolvedValue([]);
-    getTeam.mockResolvedValue([]);
     getSchedule.mockResolvedValue(null);
     getWebsite.mockResolvedValue(null);
 

--- a/__tests__/components/home/leadership-section.test.tsx
+++ b/__tests__/components/home/leadership-section.test.tsx
@@ -124,11 +124,9 @@ describe('LeadershipSection', () => {
     expect(imageContainer).toHaveClass('w-32', 'h-32');
   });
 
-  it('renders email link when email is provided', () => {
+  it('does not render email link in leadership section', () => {
     render(<LeadershipSection people={[mockTeamMember1]} />);
-    const emailLink = screen.getByRole('link', { name: 'john@example.com' });
-    expect(emailLink).toBeInTheDocument();
-    expect(emailLink).toHaveAttribute('href', 'mailto:john@example.com');
+    expect(screen.queryByRole('link', { name: 'john@example.com' })).not.toBeInTheDocument();
   });
 
   it('does not render email link when email is not provided', () => {

--- a/__tests__/components/navbar/navbar.test.tsx
+++ b/__tests__/components/navbar/navbar.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { beforeEach, vi } from 'vitest';
 import { Navbar } from '@/components/navbar/navbar';
+import { NAV_LINKS } from '@/components/navbar/nav-links';
 import * as nextNavigation from 'next/navigation';
 
 // Mock next/navigation
@@ -37,17 +38,17 @@ describe('Navbar', () => {
   });
 
   it('should render logo', () => {
-    render(<Navbar />);
+    render(<Navbar links={NAV_LINKS} />);
     expect(screen.getByText('Glenview Ultimate')).toBeInTheDocument();
   });
 
   it('should render desktop navigation', () => {
-    render(<Navbar />);
+    render(<Navbar links={NAV_LINKS} />);
     expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument();
   });
 
   it('should render register button', () => {
-    render(<Navbar />);
+    render(<Navbar links={NAV_LINKS} />);
     const registerButton = screen.getByRole('link', { name: /register/i });
     expect(registerButton).toBeInTheDocument();
     expect(registerButton).toHaveAttribute('href', '/register');
@@ -55,7 +56,7 @@ describe('Navbar', () => {
 
   it('should toggle mobile menu when button is clicked', async () => {
     const user = userEvent.setup();
-    render(<Navbar />);
+    render(<Navbar links={NAV_LINKS} />);
 
     const menuButton = screen.getByRole('button', { name: /toggle navigation/i });
     await user.click(menuButton);
@@ -67,7 +68,7 @@ describe('Navbar', () => {
 
   it('should close mobile menu when pathname changes', async () => {
     const user = userEvent.setup();
-    const { rerender } = render(<Navbar />);
+    const { rerender } = render(<Navbar links={NAV_LINKS} />);
 
     // Open menu first by clicking button
     const menuButton = screen.getByRole('button', { name: /toggle navigation/i });
@@ -78,7 +79,7 @@ describe('Navbar', () => {
 
     // Change pathname by updating the mock
     usePathname.mockReturnValue('/about');
-    rerender(<Navbar />);
+    rerender(<Navbar links={NAV_LINKS} />);
 
     // Menu should be closed (not visible)
     const mobileNav = document.getElementById('mobile-nav');

--- a/__tests__/lib/directus-fetchers.test.ts
+++ b/__tests__/lib/directus-fetchers.test.ts
@@ -93,6 +93,23 @@ describe('directus fetchers', () => {
       await expect(getNewsBySlug('miss')).resolves.toBeNull();
     });
 
+    it('hasNewsArticles returns true when articles exist', async () => {
+      mockRequest.mockImplementation(async (arg: any) => {
+        if (arg?.collection === 'News') return [{ id: 1 }];
+        return [];
+      });
+
+      const { hasNewsArticles } = await import('@/lib/directus');
+      await expect(hasNewsArticles()).resolves.toBe(true);
+    });
+
+    it('hasNewsArticles returns false when no articles exist', async () => {
+      mockRequest.mockImplementation(async () => []);
+
+      const { hasNewsArticles } = await import('@/lib/directus');
+      await expect(hasNewsArticles()).resolves.toBe(false);
+    });
+
     it('getNewsBySlug selects first when multiple returned', async () => {
       mockRequest.mockImplementation(async (arg: any) => {
         if (arg?.collection === 'News') {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import { Lexend } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar/navbar";
 import { Footer } from "@/components/footer";
+import { hasNewsArticles } from "@/lib/directus";
+import { NAV_LINKS } from "@/components/navbar/nav-links";
 
 const lexend = Lexend({
   weight: ["400", "500", "600", "700"],
@@ -17,7 +19,10 @@ export const metadata: Metadata = {
   description: "Youth Ultimate Frisbee in Glenview, IL",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }): React.JSX.Element {
+export default async function RootLayout({ children }: { children: React.ReactNode }): Promise<React.JSX.Element> {
+  const hasNews = await hasNewsArticles();
+  const filteredLinks = hasNews ? NAV_LINKS : NAV_LINKS.filter((link) => link.href !== "/news");
+
   return (
     <html lang="en" className={lexend.variable}>
       <body className={`${lexend.className} min-h-screen antialiased bg-brand-green text-white`}>
@@ -27,7 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }):
           strategy="afterInteractive"
         />
         <header className="border-b border-white/20">
-          <Navbar />
+          <Navbar links={filteredLinks} />
         </header>
         <main className="container py-10">{children}</main>
         <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,16 @@
 import React, { Suspense } from "react";
-import { getPartners, getTeam, getSchedule, getWebsite, getDirectusAssetUrl } from "@/lib/directus";
+import { getPartners, getSchedule, getWebsite, getDirectusAssetUrl } from "@/lib/directus";
 import { LOGO_ID } from "@/lib/config";
 import { HeroSection } from "@/components/home/hero-section";
 import { SeasonHighlightsCard } from "@/components/home/season-highlights-card";
-import { LeadershipSection } from "@/components/home/leadership-section";
 import { PartnersSection } from "@/components/home/partners-section";
 import { HomeVisualEditingProvider } from "../components/home/home-visual-editing-provider";
 
 export const revalidate = 300;
 
 export default async function HomePage(): Promise<React.JSX.Element> {
-  const [partners, people, season, website] = await Promise.all([
+  const [partners, season, website] = await Promise.all([
     getPartners(),
-    getTeam(),
     getSchedule(),
     getWebsite(),
   ]);
@@ -26,10 +24,7 @@ export default async function HomePage(): Promise<React.JSX.Element> {
       <HomeVisualEditingProvider directusUrl={directusUrl}>
         <div className="space-y-10">
           <HeroSection season={season} logoUrl={logoUrl} website={website} />
-          <section className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
-            <SeasonHighlightsCard highlights={highlights} />
-            <LeadershipSection people={people} />
-          </section>
+          <SeasonHighlightsCard highlights={highlights} />
           <PartnersSection partners={partners} />
         </div>
       </HomeVisualEditingProvider>

--- a/components/about/team-leadership-section.tsx
+++ b/components/about/team-leadership-section.tsx
@@ -54,7 +54,7 @@ export function TeamLeadershipSection({
             <div className="grid-2">
               {captains.map((member) => (
                 <React.Fragment key={member.id}>
-                  {renderMemberCard?.(member) ?? <TeamMemberCard member={member} />}
+                  {renderMemberCard?.(member) ?? <TeamMemberCard member={member} showEmail={false} />}
                 </React.Fragment>
               ))}
             </div>
@@ -62,7 +62,7 @@ export function TeamLeadershipSection({
           {/* Coach below, spanning full width */}
           {coach && (
             <div className="grid-2">
-              {renderMemberCard?.(coach) ?? <TeamMemberCard key={coach.id} member={coach} />}
+              {renderMemberCard?.(coach) ?? <TeamMemberCard key={coach.id} member={coach} showEmail={false} />}
             </div>
           )}
         </div>

--- a/components/home/leadership-section.tsx
+++ b/components/home/leadership-section.tsx
@@ -34,6 +34,7 @@ export function LeadershipSection({
                   member={p}
                   internalGap="compact"
                   showBio={false}
+                  showEmail={false}
                   squareImage={true}
                   {...(editingEnabled
                     ? { "data-directus": setAttr({ collection: "Team", item: p.id, fields: ["name", "role", "email"], mode: "popover" }) }

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -7,9 +7,13 @@ import { Logo } from "./logo";
 import { DesktopNav } from "./desktop-nav";
 import { MobileMenuButton } from "./mobile-menu-button";
 import { MobileMenu } from "./mobile-menu";
-import { NAV_LINKS } from "./nav-links";
+import type { NavLinkItem } from "./nav-links";
 
-export function Navbar(): React.JSX.Element {
+interface NavbarProps {
+  links: readonly NavLinkItem[];
+}
+
+export function Navbar({ links }: NavbarProps): React.JSX.Element {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
 
@@ -21,7 +25,7 @@ export function Navbar(): React.JSX.Element {
     <div className="border-b border-white/10 md:border-none">
       <div className="container py-4 flex items-center justify-between gap-3 md:gap-4">
         <Logo />
-        <DesktopNav links={NAV_LINKS} />
+        <DesktopNav links={links} />
         <div className="hidden md:block">
           <Button asChild>
             <Link href="/register">Register</Link>
@@ -29,7 +33,7 @@ export function Navbar(): React.JSX.Element {
         </div>
         <MobileMenuButton isOpen={menuOpen} onClick={() => setMenuOpen((prev) => !prev)} />
       </div>
-      <MobileMenu links={NAV_LINKS} isOpen={menuOpen} />
+      <MobileMenu links={links} isOpen={menuOpen} />
     </div>
   );
 }

--- a/lib/directus.ts
+++ b/lib/directus.ts
@@ -300,6 +300,18 @@ export function getNewsList(limit = 20): Promise<NewsPost[]> {
   );
 }
 
+export function hasNewsArticles(): Promise<boolean> {
+  return withDirectus(false, async (client) => {
+    const data = await client.request(
+      readItems("News", {
+        limit: 1,
+        fields: ["id"],
+      }),
+    );
+    return data.length > 0;
+  });
+}
+
 export function getNewsBySlug(slug: string): Promise<NewsPost | null> {
   return withDirectus<NewsPost | null>(null, async (client) => {
     const data = await client.request(


### PR DESCRIPTION
## Changes

This PR includes several UI improvements:

### 1. Hide News Link When No Articles
- Added `hasNewsArticles()` function to efficiently check if news articles exist
- Updated navigation to conditionally show/hide the News link based on article count
- Navigation now dynamically filters links based on available content

### 2. Remove Email Addresses from Leadership Cards
- Removed email addresses from leadership cards on both homepage and about page
- Updated `LeadershipSection` and `TeamLeadershipSection` to pass `showEmail={false}` to `TeamMemberCard`
- Leadership information now displays name and role only

### 3. Remove Leadership Section from Homepage
- Removed the leadership section from the homepage entirely
- Simplified homepage layout (Hero → Season Highlights → Partners)
- Leadership information is still available on the About page

## Testing

- ✅ All 531 tests pass
- ✅ Lint passes with no errors
- ✅ Build completes successfully
- ✅ Updated tests to reflect new behavior

## Files Changed

- `lib/directus.ts` - Added `hasNewsArticles()` function
- `app/layout.tsx` - Conditionally filter nav links based on news count
- `app/page.tsx` - Removed leadership section and `getTeam()` call
- `components/navbar/navbar.tsx` - Accept links as prop instead of using static array
- `components/home/leadership-section.tsx` - Set `showEmail={false}`
- `components/about/team-leadership-section.tsx` - Set `showEmail={false}` for all cards
- Test files updated to match new behavior