### PR TITLE
Add latest content card to homepage with news article or video fallback

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -8,6 +8,8 @@ vi.mock('@/lib/directus', () => ({
   getPartners: vi.fn(),
   getSchedule: vi.fn(),
   getWebsite: vi.fn(),
+  getNewsList: vi.fn(),
+  getWhatIsUltimateVideos: vi.fn(),
   getDirectusAssetUrl: vi.fn((id, options) => {
     const query = options ? '?opts=true' : '';
     return `https://example.com/assets/${id}${query}`;
@@ -29,6 +31,14 @@ vi.mock('@/components/home/season-highlights-card', () => ({
   ),
 }));
 
+vi.mock('@/components/home/latest-content-card', () => ({
+  LatestContentCard: ({ latestNews, firstVideo }: any) => (
+    <div data-testid="latest-content">
+      {latestNews ? 'Has news' : 'No news'} - {firstVideo ? 'Has video' : 'No video'}
+    </div>
+  ),
+}));
+
 vi.mock('@/components/home/partners-section', () => ({
   PartnersSection: ({ partners }: any) => <div data-testid="partners">{partners?.length || 0} partners</div>,
 }));
@@ -38,13 +48,15 @@ vi.mock('@/components/home/home-visual-editing-provider', () => ({
 }));
 
 describe('HomePage', () => {
-  let getPartners: any, getSchedule: any, getWebsite: any, getDirectusAssetUrl: any;
+  let getPartners: any, getSchedule: any, getWebsite: any, getNewsList: any, getWhatIsUltimateVideos: any, getDirectusAssetUrl: any;
 
   beforeEach(async () => {
     const directus = await import('@/lib/directus');
     getPartners = directus.getPartners;
     getSchedule = directus.getSchedule;
     getWebsite = directus.getWebsite;
+    getNewsList = directus.getNewsList;
+    getWhatIsUltimateVideos = directus.getWhatIsUltimateVideos;
     getDirectusAssetUrl = directus.getDirectusAssetUrl;
   });
 
@@ -57,49 +69,62 @@ describe('HomePage', () => {
     getPartners.mockResolvedValue([]);
     getSchedule.mockResolvedValue(null);
     getWebsite.mockResolvedValue(null);
+    getNewsList.mockResolvedValue([]);
+    getWhatIsUltimateVideos.mockResolvedValue([]);
 
     const page = await HomePage();
     const { getByTestId } = render(page);
 
     expect(getByTestId('hero-section')).toBeInTheDocument();
     expect(getByTestId('season-highlights')).toHaveTextContent('0 highlights');
+    expect(getByTestId('latest-content')).toBeInTheDocument();
     expect(getByTestId('partners')).toHaveTextContent('0 partners');
   });
 
   it('should render with fetched data', async () => {
     const mockPartners = [{ id: '1', name: 'Partner 1' }];
     const mockSchedule = {
-      highlights: [{ id: '1', title: 'Highlight 1' }],
+      highlights: ['Highlight 1'],
     };
     const mockWebsite = { id: 1, hero_title: 'Test Title' };
+    const mockNews = [{ id: 1, slug: 'test', title: 'Test News', published_at: '2026-01-01', content: 'Content' }];
 
     getPartners.mockResolvedValue(mockPartners);
     getSchedule.mockResolvedValue(mockSchedule);
     getWebsite.mockResolvedValue(mockWebsite);
+    getNewsList.mockResolvedValue(mockNews);
+    getWhatIsUltimateVideos.mockResolvedValue([]);
 
     const page = await HomePage();
     const { getByTestId } = render(page);
 
     expect(getByTestId('partners')).toHaveTextContent('1 partners');
     expect(getByTestId('season-highlights')).toHaveTextContent('1 highlights');
+    expect(getByTestId('latest-content')).toHaveTextContent('Has news');
   });
 
   it('should fetch all required data', async () => {
     getPartners.mockResolvedValue([]);
     getSchedule.mockResolvedValue(null);
     getWebsite.mockResolvedValue(null);
+    getNewsList.mockResolvedValue([]);
+    getWhatIsUltimateVideos.mockResolvedValue([]);
 
     await HomePage();
 
     expect(getPartners).toHaveBeenCalledTimes(1);
     expect(getSchedule).toHaveBeenCalledTimes(1);
     expect(getWebsite).toHaveBeenCalledTimes(1);
+    expect(getNewsList).toHaveBeenCalledWith(1);
+    expect(getWhatIsUltimateVideos).toHaveBeenCalledTimes(1);
   });
 
   it('should get logo URL', async () => {
     getPartners.mockResolvedValue([]);
     getSchedule.mockResolvedValue(null);
     getWebsite.mockResolvedValue(null);
+    getNewsList.mockResolvedValue([]);
+    getWhatIsUltimateVideos.mockResolvedValue([]);
 
     await HomePage();
 

--- a/__tests__/components/home/latest-content-card.test.tsx
+++ b/__tests__/components/home/latest-content-card.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { LatestContentCard } from '@/components/home/latest-content-card';
+import type { NewsPost, WhatIsUltimateVideo } from '@/lib/directus';
+
+// Mock SectionCard
+vi.mock('@/components/ui/section-card', () => ({
+  SectionCard: ({ title, children, className }: { title: string; children: React.ReactNode; className?: string }) => (
+    <div data-testid="section-card" className={className}>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  ),
+}));
+
+// Mock NewsArticleCard
+vi.mock('@/components/news/news-article-card', () => ({
+  NewsArticleCard: ({ post }: { post: NewsPost }) => (
+    <div data-testid="news-article-card">
+      <h3>{post.title}</h3>
+    </div>
+  ),
+}));
+
+// Mock VideoCard
+vi.mock('@/components/what-is-ultimate/video-card', () => ({
+  VideoCard: ({ title }: { title: string }) => (
+    <div data-testid="video-card">
+      <h3>{title}</h3>
+    </div>
+  ),
+}));
+
+describe('LatestContentCard', () => {
+  const mockNewsPost: NewsPost = {
+    id: 1,
+    slug: 'test-article',
+    title: 'Test News Article',
+    published_at: '2026-01-01T00:00:00Z',
+    content: 'Test content',
+    excerpt: 'Test excerpt',
+  };
+
+  const mockVideo: WhatIsUltimateVideo = {
+    id: 1,
+    title: 'Test Video',
+    description: 'Test video description',
+    youtube_embed_id: 'abc123',
+    video_url: null,
+    sort: 1,
+    active: true,
+  };
+
+  it('renders latest news when available', () => {
+    render(<LatestContentCard latestNews={mockNewsPost} />);
+    expect(screen.getByRole('heading', { level: 2, name: /Latest News/i })).toBeInTheDocument();
+    expect(screen.getByTestId('news-article-card')).toBeInTheDocument();
+    expect(screen.getByText('Test News Article')).toBeInTheDocument();
+  });
+
+  it('renders first video when no news is available', () => {
+    render(<LatestContentCard firstVideo={mockVideo} />);
+    expect(screen.getByRole('heading', { level: 2, name: /Learn More/i })).toBeInTheDocument();
+    expect(screen.getByTestId('video-card')).toBeInTheDocument();
+    expect(screen.getByText('Test Video')).toBeInTheDocument();
+  });
+
+  it('prioritizes news over video when both are available', () => {
+    render(<LatestContentCard latestNews={mockNewsPost} firstVideo={mockVideo} />);
+    expect(screen.getByRole('heading', { level: 2, name: /Latest News/i })).toBeInTheDocument();
+    expect(screen.getByTestId('news-article-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('video-card')).not.toBeInTheDocument();
+  });
+
+  it('renders empty message when no content is available', () => {
+    render(<LatestContentCard />);
+    expect(screen.getByRole('heading', { level: 2, name: /Latest Updates/i })).toBeInTheDocument();
+    expect(screen.getByText(/Content coming soon./i)).toBeInTheDocument();
+  });
+
+  it('applies custom className when provided', () => {
+    const { container } = render(<LatestContentCard latestNews={mockNewsPost} className="custom-class" />);
+    const card = container.querySelector('[data-testid="section-card"]');
+    expect(card).toHaveClass('custom-class');
+  });
+});
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,26 @@
 import React, { Suspense } from "react";
-import { getPartners, getSchedule, getWebsite, getDirectusAssetUrl } from "@/lib/directus";
+import { getPartners, getSchedule, getWebsite, getDirectusAssetUrl, getNewsList, getWhatIsUltimateVideos } from "@/lib/directus";
 import { LOGO_ID } from "@/lib/config";
 import { HeroSection } from "@/components/home/hero-section";
 import { SeasonHighlightsCard } from "@/components/home/season-highlights-card";
+import { LatestContentCard } from "@/components/home/latest-content-card";
 import { PartnersSection } from "@/components/home/partners-section";
 import { HomeVisualEditingProvider } from "../components/home/home-visual-editing-provider";
 
 export const revalidate = 300;
 
 export default async function HomePage(): Promise<React.JSX.Element> {
-  const [partners, season, website] = await Promise.all([
+  const [partners, season, website, newsList, videos] = await Promise.all([
     getPartners(),
     getSchedule(),
     getWebsite(),
+    getNewsList(1),
+    getWhatIsUltimateVideos(),
   ]);
 
   const highlights = season?.highlights ?? [];
+  const latestNews = newsList.length > 0 ? newsList[0] : null;
+  const firstVideo = videos.length > 0 ? videos[0] : null;
   const logoUrl = getDirectusAssetUrl(LOGO_ID);
   const directusUrl = process.env.DIRECTUS_URL ?? "";
 
@@ -24,7 +29,10 @@ export default async function HomePage(): Promise<React.JSX.Element> {
       <HomeVisualEditingProvider directusUrl={directusUrl}>
         <div className="space-y-10">
           <HeroSection season={season} logoUrl={logoUrl} website={website} />
-          <SeasonHighlightsCard highlights={highlights} />
+          <section className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+            <SeasonHighlightsCard highlights={highlights} />
+            <LatestContentCard latestNews={latestNews} firstVideo={firstVideo} />
+          </section>
           <PartnersSection partners={partners} />
         </div>
       </HomeVisualEditingProvider>

--- a/components/home/latest-content-card.tsx
+++ b/components/home/latest-content-card.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { NewsPost, WhatIsUltimateVideo } from "@/lib/directus";
+import { NewsArticleCard } from "@/components/news/news-article-card";
+import { VideoCard } from "@/components/what-is-ultimate/video-card";
+import { SectionCard } from "@/components/ui/section-card";
+
+export interface LatestContentCardProps {
+  latestNews?: NewsPost | null;
+  firstVideo?: WhatIsUltimateVideo | null;
+  className?: string;
+}
+
+export function LatestContentCard({
+  latestNews,
+  firstVideo,
+  className,
+}: LatestContentCardProps): React.JSX.Element {
+  // Show latest news if available, otherwise show first video
+  if (latestNews) {
+    return (
+      <SectionCard title="Latest News" className={className}>
+        <NewsArticleCard post={latestNews} />
+      </SectionCard>
+    );
+  }
+
+  if (firstVideo) {
+    return (
+      <SectionCard title="Learn More" className={className}>
+        <VideoCard
+          title={firstVideo.title}
+          description={firstVideo.description ?? ""}
+          embedId={firstVideo.youtube_embed_id ?? undefined}
+          videoUrl={firstVideo.video_url ?? undefined}
+        />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Latest Updates" className={className}>
+      <p className="text-white/90">Content coming soon.</p>
+    </SectionCard>
+  );
+}
+


### PR DESCRIPTION
## Changes

This PR adds a new dynamic content section to the homepage that replaces the previously removed leadership section.

### Latest Content Card
- Created `LatestContentCard` component that displays the newest news article when available
- Falls back to the first video from the "What is Ultimate" page if no news articles exist
- Shows a placeholder message if neither news nor videos are available
- Restores the two-column grid layout on homepage (Season Highlights + Latest Content)

### Implementation Details
- Homepage now fetches latest news article (limit 1) and videos from Directus
- Component prioritizes news over video content
- Uses existing `NewsArticleCard` and `VideoCard` components for consistent styling
- Maintains responsive grid layout that works on mobile and desktop

## Testing

- ✅ All 536 tests pass
- ✅ Lint passes with no errors
- ✅ Build completes successfully
- ✅ Added comprehensive tests for `LatestContentCard` component
- ✅ Updated homepage tests to include new data fetching

## Files Changed

- `components/home/latest-content-card.tsx` - New component for displaying latest content
- `app/page.tsx` - Updated to fetch news and videos, added grid layout with latest content
- `__tests__/components/home/latest-content-card.test.tsx` - Tests for new component
- `__tests__/app/page.test.tsx` - Updated to test new data fetching