### PR TITLE
Add Conductor workspace configuration

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,7 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+
+[scripts]
+setup = "yarn install --frozen-lockfile"
+run = "./node_modules/.bin/next dev --port $CONDUCTOR_PORT"
+archive = "rm -rf .next"
+run_mode = "concurrent"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "backup:schema": "tsx scripts/backup-schema.ts",
-    "dev": "next dev",
+    "dev": "./node_modules/.bin/next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary
- Add `.conductor/settings.toml` with setup (`yarn install --frozen-lockfile`), run (`next dev` on `CONDUCTOR_PORT`), and archive (`rm -rf .next`) scripts for parallel Conductor workspaces.
- Fix `yarn dev` to call `./node_modules/.bin/next` directly so a Ruby `bin/next` binstub on PATH no longer shadows the Next.js CLI.

## Test plan
- [x] `yarn test`
- [x] `yarn standard:check`
- [x] `yarn dev --port $CONDUCTOR_PORT` starts Next.js on the assigned workspace port
- [ ] Conductor setup script runs on new workspace creation
- [ ] Conductor Run button starts dev server successfully


Made with [Cursor](https://cursor.com)