### PR TITLE
Add doppler.yaml for local secrets setup

### DIFF
--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,7 @@
+# Binds this repo to Doppler. Run `doppler setup` after clone (or `doppler setup --no-interactive`).
+# https://docs.doppler.com/docs/cli#assign-directory-to-config
+setup:
+  - project: glenview-ultimate
+    config: dev
+# Other configs (same keys, env-specific values): stg, prd
+# Switch: doppler setup --config stg


### PR DESCRIPTION
## Summary
- Adds a committed `doppler.yaml` that binds this repo to the `glenview-ultimate` Doppler project and `dev` config.
- New contributors can run `doppler setup --no-interactive` after clone instead of manually selecting project/config.
- Documents how to switch to other configs (`stg`, `prd`) via `doppler setup --config`.

## Test plan
- [ ] Run `doppler setup --no-interactive` in a fresh clone and confirm it links to `glenview-ultimate` / `dev`
- [ ] Run `doppler run -- yarn dev` and verify env vars load correctly


Made with [Cursor](https://cursor.com)