### PR TITLE
Redesign polish pass: accessibility, motion, and visual depth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,194 @@
+# AGENTS.md — Glenview Ultimate
+
+Agent guidance for the Glenview Ultimate Frisbee club website. Next.js 16 (App Router) + Directus headless CMS.
+
+---
+
+## Essential Commands
+
+```bash
+# Dev server (uses Next.js binary directly)
+./node_modules/.bin/next dev   # or: npm run dev
+
+# Build
+yarn build          # CI uses yarn; local dev can use npm or yarn
+
+# Tests  ← Vitest, NOT Jest
+yarn test           # run once
+yarn test:watch     # watch mode
+yarn test:coverage  # with coverage report
+yarn test:ui        # Vitest browser UI
+
+# Linting
+yarn standard:check # check only (CI gate)
+yarn standard       # auto-fix
+
+# Next.js lint (separate from eslint standard)
+yarn lint
+```
+
+**Node version**: exactly `22.19.0` (`.nvmrc`). Engines gate is `>=22.14.0 <23.0.0`.
+
+---
+
+## Architecture Overview
+
+```
+app/                   Next.js App Router pages (all server components unless 'use client')
+  api/
+    register/          POST — registration form submission → Directus
+    assets/[...path]/  Proxy for Directus assets (client-component image requests)
+    revalidate/        POST — Directus webhook → Next.js revalidatePath
+components/
+  home/                Hero, season highlights, partners, latest-content card
+  navbar/              Navbar + mobile menu + nav-links constant
+  schedule/            Season calendar component
+  about/, news/, register/, what-is-ultimate/
+  ui/                  Shared primitives: SectionCard, PageHeader, etc.
+  footer.tsx
+lib/
+  directus.ts          ALL Directus SDK interaction + TypeScript interfaces
+  config.ts            LOGO_ID, DEFAULT_REVALIDATE_SECONDS
+  constants.ts         Fallback copy (hero text, description, etc.)
+  schedule-utils.ts    selectUpcomingEvents, groupEventsByMonth
+  date-utils.ts        safeParseDate
+  register-utils.ts    Registration payload helpers
+  markdown-utils.ts    marked + sanitize-html pipeline
+  visual-editing.ts    setAttr, applyVisualEditing wrappers
+  utils.ts             cn() (clsx + tailwind-merge)
+__tests__/             Mirrors app/components/lib structure; fixtures/ excluded from coverage
+```
+
+Data flow: page component → `lib/directus.ts` helper (batched with `Promise.all`) → Directus SDK → CMS. Every helper is wrapped in `withDirectus(fallback, fn)` which silently returns the fallback when env vars are absent — the site always renders without a live CMS.
+
+---
+
+## Directus Integration
+
+### Collections (schema in `directus-schema.json`)
+| Collection | Notes |
+|---|---|
+| `Website` | Singleton — hero title/block/CTA, season summary |
+| `About` | Singleton — club description, what_kids_learn array |
+| `WhatIsUltimate` | Singleton — description markdown |
+| `WhatIsUltimateVideos` | Filter `active: true`, sort by `sort` field |
+| `Schedule` | Sort `["-season_year", "date"]`; latest season extracted at runtime |
+| `Team` | Coaches/captains |
+| `Partners` | Sponsors |
+| `News` | Slugged articles; markdown content via `marked` + `sanitize-html` |
+| `Registrations` | Write-only from API route |
+
+### Asset URLs
+- **Server components**: call `getDirectusAssetUrl(fileId, opts)` — returns direct URL with `access_token`.
+- **Client components**: call `getDirectusAssetUrl(fileId, opts, true)` (pass `forceProxy = true`) — returns `/api/assets/<id>` proxy URL. Skipping `forceProxy` on client components causes hydration mismatches because the server inlines a token-bearing URL but the client can't reproduce it.
+
+### CMS fallbacks
+`lib/constants.ts` holds fallback hero copy. `DEFAULT_SCHEDULE` in `lib/directus.ts` is the hardcoded 2026 season used when Directus is unconfigured or returns no events. Always prefer CMS data; fallbacks are last resort.
+
+### Revalidation webhook
+`POST /api/revalidate` accepts Directus flow webhooks. The `REVALIDATE_SECRET` env var must match the `Authorization: Bearer <secret>` header (or body `secret` field). Maps collections to Next.js paths via `COLLECTION_TO_PATHS`.
+
+---
+
+## Key Gotchas
+
+### Test runner is Vitest, not Jest
+The copilot instructions and TESTING.md say "Jest" — ignore them. The project migrated to **Vitest**. All test files use `vi.fn()`, `vi.mock()`, `beforeAll`/`beforeEach` from `vitest`. The setup file is `vitest.setup.ts`, config is `vitest.config.ts`.
+
+### `vi.mock` must precede imports
+Vitest hoists `vi.mock(...)` but linting flags import order. Suppress with `// eslint-disable-next-line import/first` on the post-mock imports. See `__tests__/api/register/route.test.ts` for the canonical pattern.
+
+### `next/navigation` is mocked globally in `vitest.setup.ts`
+`useRouter`, `usePathname`, and `useSearchParams` are already mocked. Don't re-mock them in individual test files — override with `vi.mocked(useSearchParams).mockReturnValue(...)` instead.
+
+### `next/server` must be manually mocked in API route tests
+`NextRequest` / `NextResponse` depend on Web APIs not fully available in jsdom. Copy the mock shape from `__tests__/api/register/route.test.ts`.
+
+### Directus client is a module-level singleton
+`directusClient` is lazily initialized and cached. Tests that check "missing env vars" must `delete process.env.DIRECTUS_URL` **before** importing the module, or reset the cache with `vi.resetModules()`.
+
+### CI uses yarn with frozen lockfile
+The CI workflow runs `yarn install --frozen-lockfile`. If you add dependencies locally with `npm install`, the lockfile won't match. Use `yarn add` or commit an updated `yarn.lock`.
+
+### Turnstile env vars required for build
+CI sets `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`. Without them some registration logic may error. Copy from `.env.example` and set test values locally.
+
+### `export const dynamic = 'force-dynamic'`
+The homepage has this directive. `DEFAULT_REVALIDATE_SECONDS = 0` in `lib/config.ts` signals the same intent for other pages. The site does not use static generation by default.
+
+### News nav link is conditional
+`app/layout.tsx` calls `hasNewsArticles()` on every render and strips the `/news` link from the navbar when no articles exist. Any new nav items with similar conditional display should follow this pattern.
+
+### Visual Editing is opt-in via URL param
+Directus Visual Editing (`@directus/visual-editing`) activates only when `?visual-editing=true` is in the URL. The `setAttr` helper from `lib/visual-editing.ts` spreads `data-directus` attributes onto elements only in that mode. Never render editing attributes unconditionally.
+
+---
+
+## Code Conventions
+
+### Component structure
+```tsx
+'use client'; // only if interactive
+
+import React from "react";
+// external imports first, then internal @/ imports
+
+export interface MyComponentProps { ... } // interface directly above component
+
+export function MyComponent({ prop }: MyComponentProps): React.JSX.Element { ... }
+```
+
+- Named exports everywhere except Next.js route files (default export for page/layout).
+- `'use client'` uses single quotes as first statement.
+- Explicit `React.JSX.Element` return type on components.
+
+### Styling
+All layout/color utilities come from Tailwind. Reuse the semantic CSS classes defined in `app/globals.css` before adding new Tailwind strings:
+
+| Class | Purpose |
+|---|---|
+| `.button` | Primary CTA (white bg, brand-green text) |
+| `.button.secondary` | Ghost button |
+| `.card` | Rounded container with `white/5` bg and `white/20` border |
+| `.notice` | Info/alert box |
+| `.input` / `.select` / `.textarea` / `.label` | Form elements |
+| `.grid-2` | Responsive 2-column grid |
+| `.container` | Centered, max-w-4xl, padded |
+
+Use `cn()` from `lib/utils` for conditional class merging.
+
+Brand color: `bg-brand-green` = `#175030`. Body background is always this color. Text defaults to white.
+
+### Form validation
+API routes validate with `zod.safeParse`. Return `{ error: "..." }` with appropriate status. Directus `RECORD_NOT_UNIQUE` errors map to `{ code: "DUPLICATE_EMAIL" }` with status 409.
+
+### Date handling
+Always use `safeParseDate` from `lib/date-utils` — raw `new Date(isoString)` is unreliable across timezones. Use `Intl.DateTimeFormat` for display, not `toLocaleDateString()`.
+
+---
+
+## Environment Variables
+
+| Variable | Usage |
+|---|---|
+| `DIRECTUS_URL` | Server-only. Required for CMS reads. |
+| `DIRECTUS_STATIC_TOKEN` | Server-only. Must have create permission on Registrations. |
+| `NEXT_PUBLIC_DIRECTUS_URL` | Client-side asset base (used by visual editing). |
+| `NEXT_PUBLIC_SITE_NAME` | Page `<title>`. Defaults to "Glenview Ultimate". |
+| `REVALIDATE_SECRET` | Webhook auth for `/api/revalidate`. |
+| `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | Cloudflare Turnstile (registration form). |
+| `TURNSTILE_SECRET_KEY` | Turnstile server-side verification. |
+
+Without `DIRECTUS_URL`/`DIRECTUS_STATIC_TOKEN`, `withDirectus` returns hardcoded fallbacks silently — the site builds and runs fine.
+
+---
+
+## Testing Patterns
+
+Tests live in `__tests__/` mirroring the source tree. `__tests__/fixtures/` is excluded from coverage and test runs.
+
+**Server component pages**: Render with `render(await PageComponent(props))` — async components work with Vitest + jsdom.
+
+**API routes**: Import after `vi.mock(...)` calls. Mock `@/lib/directus` and `next/server`. Reset `process.env` in `beforeEach`/`afterAll`.
+
+**Component tests**: Use `@testing-library/react` queries. `screen.getByRole`, `screen.getByText` preferred over snapshot tests.

--- a/__tests__/components/footer.test.tsx
+++ b/__tests__/components/footer.test.tsx
@@ -26,7 +26,7 @@ describe('Footer', () => {
     const footer = container.querySelector('footer');
 
     expect(footer).toBeInTheDocument();
-    expect(footer).toHaveClass('border-t', 'border-white/20', 'mt-4');
+    expect(footer).toHaveClass('border-t', 'border-white/20', 'mt-8');
   });
 
   it('should have container div with correct classes', () => {
@@ -34,6 +34,6 @@ describe('Footer', () => {
     const containerDiv = container.querySelector('.container');
 
     expect(containerDiv).toBeInTheDocument();
-    expect(containerDiv).toHaveClass('py-8', 'text-sm', 'text-white/70', 'flex', 'justify-between', 'items-center');
+    expect(containerDiv).toHaveClass('py-8', 'space-y-6');
   });
 });

--- a/__tests__/components/navbar/navbar.test.tsx
+++ b/__tests__/components/navbar/navbar.test.tsx
@@ -48,7 +48,7 @@ describe('Navbar', () => {
     usePathname.mockReturnValue('/about');
     render(<Navbar links={NAV_LINKS} />);
     const aboutLink = screen.getByRole('link', { name: /about/i });
-    expect(aboutLink).toHaveClass('bg-white/20', 'text-white');
+    expect(aboutLink).toHaveClass('text-white', 'after:opacity-100');
   });
 
   it('toggles mobile menu and closes on route change', async () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,14 +15,27 @@
 :root { color-scheme: light; }
 
 @layer base {
+  html {
+    scroll-behavior: smooth;
+  }
   html, body {
-    @apply min-h-screen antialiased;
+    min-height: 100dvh;
+    @apply antialiased;
     background-color: var(--color-brand-green);
     color: #ffffff;
   }
   a { @apply text-inherit no-underline; }
   *, *::before, *::after { @apply box-border; }
   input, select, textarea, button { @apply font-sans; }
+  h1, h2, h3, h4 {
+    text-wrap: balance;
+    letter-spacing: -0.02em;
+  }
+  :focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.7);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
 }
 
 @layer components {
@@ -43,14 +56,27 @@
     }
   }
 
-  .button { @apply inline-flex items-center justify-center rounded-lg border border-white bg-white px-4 py-2 text-brand-green text-sm font-medium hover:bg-white/90 transition-colors; }
-  .button.secondary { @apply bg-transparent text-white border-white/30 hover:bg-white/10; }
-  .input { @apply w-full rounded-lg border-white/30 bg-white/10 text-white px-3 py-2 placeholder:text-white/50; }
-  .select { @apply w-full rounded-lg border-white/30 bg-white/10 text-white px-3 py-2; }
+  .button {
+    @apply inline-flex items-center justify-center rounded-lg border border-white bg-white px-4 py-2 text-brand-green text-sm font-medium transition-all duration-200;
+    @apply hover:bg-white/90;
+  }
+  .button:active { transform: scale(0.97) translateY(1px); }
+  .button.secondary { @apply bg-transparent text-white border-white/30 hover:bg-white/10 hover:border-white/50; }
+  .input { @apply w-full rounded-lg border border-white/30 bg-white/10 text-white px-3 py-2 placeholder:text-white/50 transition-colors duration-150 hover:border-white/50 focus:border-white/60; }
+  .select { @apply w-full rounded-lg border border-white/30 bg-white/10 text-white px-3 py-2; }
   .select option { @apply bg-brand-green text-white; }
-  .textarea { @apply w-full rounded-lg border-white/30 bg-white/10 text-white px-3 py-2 placeholder:text-white/50; }
+  .textarea { @apply w-full rounded-lg border border-white/30 bg-white/10 text-white px-3 py-2 placeholder:text-white/50 transition-colors duration-150 hover:border-white/50; }
   .label { @apply block text-white text-sm mb-1; }
-  .card { @apply rounded-xl border border-white/20 bg-white/5 p-4; }
+  .card {
+    @apply rounded-xl border border-white/20 bg-white/5 p-4;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
   .notice { @apply rounded-lg border border-white/20 bg-white/10 p-4; }
   .grid-2 { @apply grid grid-cols-1 md:grid-cols-2 gap-4; }
+  .skip-link {
+    @apply sr-only;
+  }
+  .skip-link:focus {
+    @apply not-sr-only fixed top-4 left-4 z-50 px-4 py-2 rounded-lg bg-white text-brand-green text-sm font-semibold;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,16 +25,17 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   return (
     <html lang="en" className={lexend.variable}>
-      <body className={`${lexend.className} min-h-screen antialiased bg-brand-green text-white`}>
+      <body className={`${lexend.className} min-h-dvh antialiased bg-brand-green text-white`}>
         <Script
           src="https://umami.glenview-ultimate.org/script.js"
           data-website-id="c374c9b6-a4c4-4c42-837e-681db5fb70f0"
           strategy="afterInteractive"
         />
+        <a href="#main-content" className="skip-link">Skip to content</a>
         <header className="border-b border-white/20">
           <Navbar links={filteredLinks} />
         </header>
-        <main className="container py-10">{children}</main>
+        <main id="main-content" className="container py-10">{children}</main>
         <Footer />
       </body>
     </html>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,13 +1,44 @@
 import React from "react";
+import Link from "next/link";
+
+const FOOTER_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/about", label: "About" },
+  { href: "/schedule", label: "Schedule" },
+  { href: "/what-is-ultimate", label: "What is Ultimate?" },
+  { href: "/register", label: "Register" },
+];
 
 export function Footer(): React.JSX.Element {
   return (
-    <footer className="border-t border-white/20 mt-4">
-      <div className="container py-8 text-sm text-white/70 flex justify-between items-center">
-        <div>© {new Date().getFullYear()} Glenview Ultimate</div>
-        <div className="text-right">made with love by <a href="https://ericdahl.dev" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">ericdahl.dev</a></div>
+    <footer className="border-t border-white/20 mt-8">
+      <div className="container py-8 space-y-6">
+        <nav aria-label="Footer navigation" className="flex flex-wrap justify-center gap-x-6 gap-y-2">
+          {FOOTER_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-sm text-white/60 hover:text-white transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-2 text-sm text-white/50">
+          <div>© {new Date().getFullYear()} Glenview Ultimate</div>
+          <div>
+            made with love by{" "}
+            <a
+              href="https://ericdahl.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white transition-colors"
+            >
+              ericdahl.dev
+            </a>
+          </div>
+        </div>
       </div>
     </footer>
   );
 }
-

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -36,7 +36,11 @@ export function HeroSection({ logoUrl, website, className }: HeroSectionProps): 
   const sanitizedSeasonSummary = website?.season_summary ? sanitizeHtml(website.season_summary) : null;
 
   return (
-    <section className={cn("text-center space-y-4", className)}>
+    <section className={cn("relative text-center space-y-5 py-6", className)}>
+      {/* ambient glow behind logo */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center" aria-hidden="true">
+        <div className="h-64 w-96 rounded-full bg-white/5 blur-3xl" />
+      </div>
       {logoUrl && (
         <div className="flex justify-center mb-6">
           <Image
@@ -52,7 +56,7 @@ export function HeroSection({ logoUrl, website, className }: HeroSectionProps): 
         </div>
       )}
       <h1
-        className="text-3xl md:text-5xl font-bold text-white"
+        className="text-4xl md:text-6xl font-bold text-white leading-tight"
         {...(editingEnabled && websiteId
           ? {
               "data-directus": setAttr({

--- a/components/navbar/nav-link.tsx
+++ b/components/navbar/nav-link.tsx
@@ -17,8 +17,9 @@ export function NavLink({ href, label, className }: NavLinkProps): React.JSX.Ele
     <Link
       href={href}
       className={cn(
-        "px-2 py-1 rounded-md text-white/80 hover:text-white transition-colors",
-        isActive && "bg-white/20 text-white",
+        "relative px-1 py-1 text-white/70 hover:text-white transition-colors duration-150",
+        "after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:rounded-full after:bg-white after:transition-opacity after:duration-150",
+        isActive ? "text-white after:opacity-100" : "after:opacity-0 hover:after:opacity-30",
         className
       )}
     >


### PR DESCRIPTION
## Summary

- **Accessibility**: skip-to-content link, `id="main-content"`, global `:focus-visible` ring
- **Layout/motion**: `min-h-dvh` fixes iOS Safari viewport jump; `scroll-behavior: smooth`; button active/press feedback (`scale + translateY`); input/card hover transitions
- **Typography**: `text-wrap: balance` + tighter letter-spacing on all headings
- **Visual depth**: cards get a subtle inset highlight shadow; hero gets a radial ambient glow behind the logo; larger hero headline
- **Footer**: rebuilt with navigation links to all 5 pages; restructured copyright/credit row
- **Nav**: replaced generic `bg-white/20` active pill with a bottom-border underline indicator
- **AGENTS.md**: added agent context doc for future AI work in this repo

## Test plan

- [x] Updated `footer.test.tsx` class assertions to match new structure
- [x] Updated `navbar.test.tsx` active-state assertion to match underline classes
- [ ] Verify visual pass in browser (iOS Safari viewport, hover states, skip link on Tab)