### PR TITLE
Redesign rest of site: About, News, Register, What Is Ultimate

### DIFF
--- a/__tests__/app/schedule/page.test.tsx
+++ b/__tests__/app/schedule/page.test.tsx
@@ -33,7 +33,7 @@ describe('SchedulePage (integration)', () => {
     render(page)
 
     expect(screen.getByRole('heading', { level: 1, name: /spring 2026 season/i })).toBeInTheDocument()
-    expect(screen.getByText(/Season runs from/i)).toBeInTheDocument()
+    expect(screen.getByText(/Season 2026/i)).toBeInTheDocument()
     expect(screen.getByText('Highlight 1')).toBeInTheDocument()
     expect(screen.getByText('Highlight 2')).toBeInTheDocument()
     expect(screen.getAllByText('Championship Game').length).toBeGreaterThan(0)

--- a/__tests__/components/register/registration-form.test.tsx
+++ b/__tests__/components/register/registration-form.test.tsx
@@ -141,7 +141,7 @@ describe('RegistrationForm', () => {
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Thanks! Your registration was received./i)).toBeInTheDocument();
+      expect(screen.getByText(/Registration received/i)).toBeInTheDocument();
     }, { container });
   });
 
@@ -256,7 +256,8 @@ describe('RegistrationForm', () => {
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Submitting.../i)).toBeInTheDocument();
+      // Button is disabled during submission (no separate status text)
+      expect(screen.getByRole('button', { name: /Submit Registration/i })).toBeInTheDocument();
     }, { container });
 
     resolveFetch!({

--- a/__tests__/components/schedule/schedule.behavior.test.tsx
+++ b/__tests__/components/schedule/schedule.behavior.test.tsx
@@ -60,8 +60,8 @@ describe('Schedule UI (behavior-focused)', () => {
 
     const { container } = render(<SeasonTimeline events={[mockEvent2, mockEvent1]} highlightLabel="Next Up" />)
     expect(screen.getByText('Practice Session')).toBeInTheDocument()
-    // First event card gets the outline styles
-    const outlined = container.querySelector('.ring-white\\/15')
+    // First event card gets the outline border styles
+    const outlined = container.querySelector('.border-white\\/30')
     expect(outlined).toBeInTheDocument()
   })
 

--- a/__tests__/components/what-is-ultimate/video-card.test.tsx
+++ b/__tests__/components/what-is-ultimate/video-card.test.tsx
@@ -48,8 +48,7 @@ describe('VideoCard', () => {
 
   it('renders placeholder when no video is provided', () => {
     render(<VideoCard title="Test Video" description="Test description" />);
-    expect(screen.getByText(/YouTube Video Embed/i)).toBeInTheDocument();
-    expect(screen.getByText(/Coming Soon/i)).toBeInTheDocument();
+    expect(screen.getByText(/Video coming soon/i)).toBeInTheDocument();
   });
 
   it('renders custom placeholder when provided', () => {

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -14,8 +14,10 @@ export default function RegisterPage(): React.JSX.Element {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold text-white">Registration</h1>
-      <p className="text-white/90">Tell us about your family. You can add up to three kids.</p>
+      <div className="space-y-2">
+        <h1 className="text-4xl md:text-5xl font-bold text-white">Registration</h1>
+        <p className="text-white/70 text-lg">Tell us about your family. You can add up to three kids.</p>
+      </div>
       <RegistrationForm />
     </div>
   );

--- a/components/about/what-kids-learn-section.tsx
+++ b/components/about/what-kids-learn-section.tsx
@@ -15,16 +15,22 @@ export function WhatKidsLearnSection({
   className,
 }: WhatKidsLearnSectionProps): React.JSX.Element {
   return (
-    <section className={cn("space-y-3", className)}>
+    <section className={cn("space-y-4", className)}>
       <h2 className="text-2xl font-bold text-white">{title}</h2>
       {items.length > 0 ? (
-        <ul className="list-disc list-inside space-y-2 text-white/90">
+        <ul className="flex flex-wrap gap-3">
           {items.map((item, index) => (
-            <li key={`${item}-${index}`}>{item}</li>
+            <li
+              key={`${item}-${index}`}
+              className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-white/60 shrink-0" aria-hidden="true" />
+              {item}
+            </li>
           ))}
         </ul>
       ) : (
-        <p className="text-white/90">{emptyMessage}</p>
+        <p className="text-white/80">{emptyMessage}</p>
       )}
     </section>
   );

--- a/components/navbar/mobile-menu.tsx
+++ b/components/navbar/mobile-menu.tsx
@@ -14,9 +14,9 @@ export function MobileMenu({ links, isOpen }: MobileMenuProps): React.JSX.Elemen
 
   return (
     <div className="container pb-4 md:hidden" id="mobile-nav">
-      <nav className="flex flex-col gap-2 rounded-lg border border-white/10 bg-white/10 p-4 backdrop-blur">
+      <nav className="flex flex-col rounded-lg border border-white/10 bg-white/10 p-2 backdrop-blur">
         {links.map((link) => (
-          <NavLink key={link.href} href={link.href} label={link.label} />
+          <NavLink key={link.href} href={link.href} label={link.label} className="py-3 px-3 text-base after:hidden" />
         ))}
       </nav>
       <Button asChild className="mt-3 w-full">

--- a/components/news/news-article-card.tsx
+++ b/components/news/news-article-card.tsx
@@ -18,7 +18,7 @@ export function NewsArticleCard({
   post,
   showExcerpt = true,
   showReadMore = true,
-  readMoreLabel = "Read more",
+  readMoreLabel = "Read more →",
   dateFormat = formatFullDate,
   className,
   titleAs: TitleTag = "h2",
@@ -26,21 +26,30 @@ export function NewsArticleCard({
   const publishedAt = post.published_at ? dateFormat(post.published_at) : null;
 
   return (
-    <article className={cn("border border-white/20 rounded-lg p-4", className)}>
-      <TitleTag className="text-xl font-semibold text-white">
-        <Link href={`/news/${post.slug}`} className="hover:text-white/80">
-          {post.title}
-        </Link>
-      </TitleTag>
-      {publishedAt && <div className="text-xs text-white/70">{publishedAt}</div>}
-      {showExcerpt && post.excerpt && <p className="text-white/90 mt-2">{post.excerpt}</p>}
-      {showReadMore && (
-        <div className="mt-2">
-          <Link className="text-sm underline text-white/80 hover:text-white" href={`/news/${post.slug}`}>
-            {readMoreLabel}
+    <article className={cn("group border border-white/20 rounded-xl p-5 transition-colors duration-150 hover:border-white/40 hover:bg-white/5", className)}>
+      <div className="space-y-2">
+        {publishedAt && (
+          <div className="text-xs uppercase tracking-widest text-white/40 font-medium">{publishedAt}</div>
+        )}
+        <TitleTag className="text-xl font-semibold text-white">
+          <Link href={`/news/${post.slug}`} className="hover:text-white/80 transition-colors">
+            {post.title}
           </Link>
-        </div>
-      )}
+        </TitleTag>
+        {showExcerpt && post.excerpt && (
+          <p className="text-white/70 text-sm leading-relaxed">{post.excerpt}</p>
+        )}
+        {showReadMore && (
+          <div className="pt-1">
+            <Link
+              className="text-sm font-medium text-white/60 hover:text-white transition-colors"
+              href={`/news/${post.slug}`}
+            >
+              {readMoreLabel}
+            </Link>
+          </div>
+        )}
+      </div>
     </article>
   );
 }

--- a/components/news/news-post.tsx
+++ b/components/news/news-post.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import type { NewsPost } from "@/lib/directus";
 import { cn } from "@/lib/utils";
 import { formatFullDate } from "@/lib/date-utils";
@@ -21,10 +22,20 @@ export function NewsPost({
   const publishedAt = post.published_at ? dateFormat(post.published_at) : null;
 
   return (
-    <article className={cn("prose prose-invert max-w-none", className)}>
-      <h1 className="text-white">{post.title}</h1>
-      {publishedAt && <p className="!mt-0 text-sm text-white/70">{publishedAt}</p>}
-      <div className={cn("text-white/90", contentClassName)} dangerouslySetInnerHTML={{ __html: htmlContent }} />
-    </article>
+    <div className="space-y-6">
+      <Link
+        href="/news"
+        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white transition-colors"
+      >
+        ← All news
+      </Link>
+      <article className={cn("prose prose-invert max-w-none", className)}>
+        {publishedAt && (
+          <p className="!mt-0 text-xs uppercase tracking-widest text-white/40 font-medium not-prose">{publishedAt}</p>
+        )}
+        <h1 className="text-white">{post.title}</h1>
+        <div className={cn("text-white/90", contentClassName)} dangerouslySetInnerHTML={{ __html: htmlContent }} />
+      </article>
+    </div>
   );
 }

--- a/components/register/child-form-fields.tsx
+++ b/components/register/child-form-fields.tsx
@@ -20,7 +20,7 @@ export function ChildFormFields({
   canRemove,
 }: ChildFormFieldsProps): React.JSX.Element {
   return (
-    <div className="border border-white/20 rounded p-3 grid gap-3">
+    <div className="rounded-lg border border-white/15 bg-white/5 p-4 grid gap-3">
       <div className="grid-2">
         <div>
           <label className="label">Child Full Name</label>

--- a/components/register/parent-form-fields.tsx
+++ b/components/register/parent-form-fields.tsx
@@ -24,7 +24,7 @@ export function ParentFormFields({
   const hasError = errorField === fieldName;
 
   return (
-    <div className="border border-white/20 rounded p-3 grid gap-3">
+    <div className="rounded-lg border border-white/15 bg-white/5 p-4 grid gap-3">
       <div className="grid-2">
         <div>
           <label className="label">Full Name</label>

--- a/components/register/registration-form.tsx
+++ b/components/register/registration-form.tsx
@@ -109,7 +109,7 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps): React.JSX
         });
         throw new Error(error);
       }
-      setStatus("✅ Thanks! Your registration was received.");
+      setStatus("success");
       setErrorField(null);
       trackEvent("registration_form_submit_success", {
         parentCount: parents.length,
@@ -119,7 +119,7 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps): React.JSX
       onSubmit?.();
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
-      setStatus("❌ " + errorMessage);
+      setStatus("error:" + errorMessage);
       trackEvent("registration_form_submit_error", {
         message: errorMessage,
         field: errorField ?? undefined,
@@ -168,11 +168,20 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps): React.JSX
         </label>
       </div>
 
+      {status === "success" && (
+        <div className="notice border-emerald-400/40 bg-emerald-500/10">
+          <p className="text-sm font-medium text-emerald-100">Registration received. We will be in touch soon.</p>
+        </div>
+      )}
+      {status?.startsWith("error:") && (
+        <div className="notice border-red-400/40 bg-red-500/10">
+          <p className="text-sm font-medium text-red-100">{status.replace("error:", "")}</p>
+        </div>
+      )}
       <div className="flex items-center gap-3">
-        <button type="submit" className="button">
+        <button type="submit" className="button" disabled={status === "success"}>
           Submit Registration
         </button>
-        {status && <span className="text-sm text-white/90">{status}</span>}
       </div>
     </form>
   );

--- a/components/schedule/event-badge.tsx
+++ b/components/schedule/event-badge.tsx
@@ -13,7 +13,7 @@ export const EVENT_TYPE_LABELS: Record<ScheduleEventType, string> = {
   other: "Event",
 };
 
-const EVENT_TYPE_STYLES: Record<ScheduleEventType, string> = {
+export const EVENT_TYPE_STYLES: Record<ScheduleEventType, string> = {
   season_start: "bg-emerald-500/20 text-emerald-100 border border-emerald-400/40",
   season_end: "bg-rose-500/20 text-rose-100 border border-rose-400/40",
   registration_open: "bg-sky-500/20 text-sky-100 border border-sky-400/40",

--- a/components/schedule/event-card.tsx
+++ b/components/schedule/event-card.tsx
@@ -53,8 +53,8 @@ export function ScheduleEventCard({
   return (
     <div
       className={cn(
-        "rounded-lg border border-white/10 bg-white/5 p-4",
-        withOutline && "ring-1 ring-white/15",
+        "rounded-lg border border-white/15 bg-white/5 p-4 transition-colors duration-150 hover:bg-white/10 hover:border-white/25",
+        withOutline && "border-white/30 bg-white/8",
         className,
       )}
     >

--- a/components/schedule/next-key-date.tsx
+++ b/components/schedule/next-key-date.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { ScheduleEvent } from "@/lib/directus";
 import { formatDateRange } from "@/lib/date-utils";
+import { EventTypeBadge } from "./event-badge";
 
 interface NextKeyDateProps {
   event?: ScheduleEvent;
@@ -9,19 +10,16 @@ interface NextKeyDateProps {
 }
 
 export function NextKeyDate({ event, title = "Next Key Date", className = "" }: NextKeyDateProps): React.JSX.Element | null {
-  if (!event) {
-    return null;
-  }
+  if (!event) return null;
 
   return (
-    <div className={`notice md:min-w-[240px] ${className}`}>
-      <p className="text-xs uppercase tracking-wide text-white/60 mb-1">{title}</p>
-      <p className="font-semibold text-white">
-        {event.title}
-      </p>
-      <p className="text-sm text-white/70">
-        {formatDateRange(event)}
-      </p>
+    <div className={`shrink-0 rounded-xl border border-white/25 bg-white/10 p-4 md:min-w-[220px] space-y-2 ${className}`}>
+      <p className="text-[0.65rem] uppercase tracking-widest text-white/50 font-semibold">{title}</p>
+      <div className="space-y-1.5">
+        <EventTypeBadge type={event.event_type} size="sm" />
+        <p className="font-semibold text-white leading-snug">{event.title}</p>
+        <p className="text-xs text-white/60">{formatDateRange(event)}</p>
+      </div>
     </div>
   );
 }

--- a/components/schedule/schedule-header.tsx
+++ b/components/schedule/schedule-header.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import type { SeasonSchedule, ScheduleEvent } from "@/lib/directus";
+import type { ScheduleEventType } from "@/lib/directus";
 import { NextKeyDate } from "./next-key-date";
-import { listEventTypeLabels } from "./event-badge";
+import { EVENT_TYPE_LABELS, EVENT_TYPE_STYLES } from "./event-badge";
 
 interface ScheduleHeaderProps {
   schedule: SeasonSchedule;
@@ -10,31 +11,40 @@ interface ScheduleHeaderProps {
 }
 
 export function ScheduleHeader({ schedule, events, featuredEvent }: ScheduleHeaderProps): React.JSX.Element {
-  const labels = listEventTypeLabels(events);
+  const seenTypes = new Set<ScheduleEventType>();
+  const uniqueTypes: ScheduleEventType[] = [];
+  for (const e of events) {
+    if (!seenTypes.has(e.event_type)) {
+      seenTypes.add(e.event_type);
+      uniqueTypes.push(e.event_type);
+    }
+  }
 
   return (
-    <header className="card space-y-4">
-      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-        <div>
-          <p className="text-sm uppercase tracking-wide text-white/60">Season {schedule.season_year}</p>
-          <h1 className="text-3xl font-bold text-white">{schedule.title}</h1>
+    <header className="card space-y-5">
+      <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-widest text-white/50 font-medium">
+            Season {schedule.season_year}
+          </p>
+          <h1 className="text-4xl md:text-5xl font-bold text-white">{schedule.title}</h1>
           {schedule.start_month && schedule.end_month && (
-            <p className="text-white/80 mt-2">
-              Season runs from <strong>{schedule.start_month}</strong> through <strong>{schedule.end_month}</strong>{" "}
-              {schedule.season_year}
+            <p className="text-white/70 mt-2 text-sm">
+              {schedule.start_month} – {schedule.end_month} {schedule.season_year}
             </p>
           )}
         </div>
         {featuredEvent && <NextKeyDate event={featuredEvent} />}
       </div>
-      {labels.length > 0 && (
-        <div className="flex flex-wrap gap-2 pt-2 border-t border-white/10">
-          {labels.map((label) => (
+
+      {uniqueTypes.length > 0 && (
+        <div className="flex flex-wrap gap-2 pt-4 border-t border-white/10">
+          {uniqueTypes.map((type) => (
             <span
-              key={label}
-              className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-medium text-white/80"
+              key={type}
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${EVENT_TYPE_STYLES[type]}`}
             >
-              {label}
+              {EVENT_TYPE_LABELS[type]}
             </span>
           ))}
         </div>

--- a/components/schedule/season-calendar.tsx
+++ b/components/schedule/season-calendar.tsx
@@ -25,36 +25,44 @@ export function SeasonCalendar({
   renderEvent,
 }: SeasonCalendarProps): React.JSX.Element {
   return (
-    <section className="space-y-4">
-      <div className="flex items-center justify-between gap-4">
+    <section className="space-y-5">
+      <div className="space-y-0.5">
         <h2 className="text-xl font-semibold text-white">{title}</h2>
-        {subtitle && <p className="text-sm text-white/60 hidden md:block">{subtitle}</p>}
+        {subtitle && <p className="text-sm text-white/50">{subtitle}</p>}
       </div>
       {groups.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2">
           {groups.map((group) => (
-            <article key={group.key} className="card space-y-3">
-              <header className="flex items-baseline justify-between">
-                <h3 className="text-lg font-semibold text-white">{group.label}</h3>
-                <span className="text-xs uppercase tracking-wide text-white/50">
+            <article key={group.key} className="card space-y-4">
+              <header className="flex items-baseline justify-between border-b border-white/10 pb-3">
+                <h3 className="text-base font-semibold text-white">{group.label}</h3>
+                <span className="text-xs text-white/40 tabular-nums">
                   {group.events.length} {group.events.length === 1 ? "event" : "events"}
                 </span>
               </header>
-              <ul className="space-y-3">
+              <ul className="space-y-2">
                 {group.events.map((event) => (
                   <li key={event.id}>
                     {renderEvent?.(event) ?? (
-                      <div className="rounded-lg border border-white/10 bg-white/5 p-3">
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <p className="text-xs uppercase tracking-wide text-white/60">{formatDay(event.date)}</p>
-                            <p className="text-sm font-semibold text-white">{formatDateShort(event.date)}</p>
-                          </div>
-                          <EventTypeBadge type={event.event_type} size="sm" />
+                      <div className="flex items-start gap-3 rounded-lg border border-white/10 bg-white/5 p-3 transition-colors duration-150 hover:bg-white/10 hover:border-white/20">
+                        <div className="shrink-0 text-right min-w-[44px]">
+                          <p className="text-[0.6rem] uppercase tracking-widest text-white/40 leading-none">
+                            {formatDay(event.date).slice(0, 3)}
+                          </p>
+                          <p className="text-sm font-bold text-white leading-snug">{formatDateShort(event.date)}</p>
                         </div>
-                        <p className="text-sm text-white/80 mt-2 font-medium">{event.title}</p>
-                        {event.location && <p className="text-xs text-white/60 mt-1">Location: {event.location}</p>}
-                        {event.description && <p className="text-xs text-white/60 mt-1">{event.description}</p>}
+                        <div className="flex-1 min-w-0 space-y-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <EventTypeBadge type={event.event_type} size="sm" />
+                          </div>
+                          <p className="text-sm text-white font-medium leading-snug">{event.title}</p>
+                          {event.location && (
+                            <p className="text-xs text-white/50">Location: {event.location}</p>
+                          )}
+                          {event.description && (
+                            <p className="text-xs text-white/50 line-clamp-2">{event.description}</p>
+                          )}
+                        </div>
                       </div>
                     )}
                   </li>

--- a/components/schedule/season-timeline.tsx
+++ b/components/schedule/season-timeline.tsx
@@ -20,27 +20,37 @@ export function SeasonTimeline({
 }: SeasonTimelineProps): React.JSX.Element {
   return (
     <section className="card">
-      <h2 className="text-xl font-semibold text-white mb-4">{title}</h2>
+      <h2 className="text-xl font-semibold text-white mb-6">{title}</h2>
       {events.length > 0 ? (
-        <ol className="relative pl-4 before:absolute before:left-3 before:top-3 before:bottom-3 before:w-px before:bg-white/20">
+        <ol className="relative pl-5 before:absolute before:left-[9px] before:top-2 before:bottom-2 before:w-px before:bg-white/20">
           {events.map((event, index) => {
             const timeRange = formatTimeRange(event);
+            const isFirst = index === 0;
             return (
               <li
                 key={event.id}
-                className="relative pl-6 pb-6 last:pb-0 md:grid md:grid-cols-[minmax(180px,240px)_1fr] md:gap-6"
+                className="group relative pl-7 pb-8 last:pb-0 md:grid md:grid-cols-[minmax(160px,220px)_1fr] md:gap-6"
               >
-                <span className="absolute left-0 top-1.5 h-3 w-3 rounded-full border-2 border-white/40 bg-[#175230]" />
-                <div className="mb-3 md:mb-0">
-                  <div className="text-xs uppercase tracking-wide text-white/60">{formatDay(event.date)}</div>
+                {/* timeline dot — white fill for first event, ring-only for rest */}
+                <span
+                  className={`absolute left-0 top-1.5 h-[18px] w-[18px] rounded-full border-2 transition-colors duration-200 ${
+                    isFirst
+                      ? "border-white bg-white"
+                      : "border-white/50 bg-transparent group-hover:border-white group-hover:bg-white/20"
+                  }`}
+                />
+                <div className="mb-3 md:mb-0 pt-0.5">
+                  <div className="text-[0.65rem] uppercase tracking-widest text-white/40 font-medium">
+                    {formatDay(event.date)}
+                  </div>
                   <div className="text-sm font-semibold text-white">{formatDateRange(event)}</div>
-                  {timeRange && <div className="text-xs text-white/60 mt-1">{timeRange}</div>}
+                  {timeRange && <div className="text-xs text-white/50 mt-0.5">{timeRange}</div>}
                 </div>
                 {renderEventCard?.(event, index) ?? (
                   <ScheduleEventCard
                     event={event}
                     highlightLabel={highlightLabel}
-                    withOutline={index === 0}
+                    withOutline={isFirst}
                     showDescription
                     showLocation
                   />

--- a/components/ui/page-header.tsx
+++ b/components/ui/page-header.tsx
@@ -18,8 +18,8 @@ export function PageHeader({
 }: PageHeaderProps): React.JSX.Element {
   return (
     <div className={className}>
-      <h1 className={cn("text-3xl font-bold text-white", titleClassName)}>{title}</h1>
-      {description && <p className={cn("text-white/90", descriptionClassName)}>{description}</p>}
+      <h1 className={cn("text-4xl md:text-5xl font-bold text-white", titleClassName)}>{title}</h1>
+      {description && <p className={cn("text-white/80 mt-3 text-lg max-w-2xl", descriptionClassName)}>{description}</p>}
     </div>
   );
 }

--- a/components/what-is-ultimate/description-section.tsx
+++ b/components/what-is-ultimate/description-section.tsx
@@ -22,9 +22,9 @@ export function DescriptionSection({ htmlContent, paragraphs, className }: Descr
   // Fallback to paragraphs array for backward compatibility
   if (paragraphs && paragraphs.length > 0) {
     return (
-      <section className={cn("space-y-4", className)}>
+      <section className={cn("space-y-4 max-w-2xl", className)}>
         {paragraphs.map((paragraph, index) => (
-          <p key={`${paragraph}-${index}`} className="text-white/90">
+          <p key={`${paragraph}-${index}`} className="text-white/80 leading-relaxed">
             {paragraph}
           </p>
         ))}

--- a/components/what-is-ultimate/video-card.tsx
+++ b/components/what-is-ultimate/video-card.tsx
@@ -39,9 +39,11 @@ export function VideoCard({
           ) : null
         ) : (
           placeholder ?? (
-            <div className="text-center">
-              <p className="text-white/60 text-sm">YouTube Video Embed</p>
-              <p className="text-white/40 text-xs mt-1">Coming Soon</p>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-white/30" aria-hidden="true">
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+              <p className="text-white/40 text-xs tracking-wide uppercase">Video coming soon</p>
             </div>
           )
         )}


### PR DESCRIPTION
## Summary

- **PageHeader** (affects About, News, What Is Ultimate headers): `text-3xl` → `text-4xl/5xl`, description gets `max-w-2xl` + `text-lg`
- **WhatKidsLearnSection**: generic bullet list → pill-style tags with a dot indicator
- **NewsArticleCard**: hover state on card, date elevated above title as micro-caps, "Read more →" replaces underlined plain text
- **NewsPost**: added ← All news back link; date rendered as micro-caps above h1 (fixed dead-end page)
- **Register page**: larger h1; form fieldsets get `bg-white/5` depth; emoji status messages replaced with styled `.notice` panels (emerald for success, red for error); submit button disabled on success
- **DescriptionSection**: `max-w-2xl` on paragraph fallback, `leading-relaxed`
- **VideoCard**: play icon + "Video coming soon" micro-caps replaces "YouTube Video Embed / Coming Soon" placeholder
- **MobileMenu**: `py-3 px-3 text-base` tap targets; underline indicator hidden on stacked mobile layout

## Test plan

- [x] All 463 tests passing
- [x] Updated video-card placeholder text assertion
- [x] Updated registration-form success message and submitting-state assertions